### PR TITLE
Add switch for parking assist laser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 
-All notable changes to `homekit-ratgdo` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
+**v3.x.x firmware is for ratgdo32 and ratgdo32-disco boards only**
+
+All notable changes to `homekit-ratgdo32` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
+
+## v3.0.4 (2024-12-21)
+
+### What's Changed
+
+* Feature: Add HomeKit light switch and web page button for parking assist laser
+* Feature: Change web page separated buttons for on/off, open/close, etc. to single buttons
+
+### Known Issues
+
+* Still testing... Future updates MAY include breaking changes requiring a flash erase and re-upload.
 
 ## v3.0.3 (2024-12-19)
 
@@ -15,7 +28,7 @@ All notable changes to `homekit-ratgdo` will be documented in this file. This pr
 
 ### Known Issues
 
-* Still testing... Future updates MAY include breaking changes reqiring a flash erase and re-upload.
+* Still testing... Future updates MAY include breaking changes requiring a flash erase and re-upload.
 
 ## v3.0.2 (2024-12-16)
 
@@ -28,7 +41,7 @@ All notable changes to `homekit-ratgdo` will be documented in this file. This pr
 
 ### Known Issues
 
-* Still testing... Future updates MAY include breaking changes reqiring a flash erase and re-upload.
+* Still testing... Future updates MAY include breaking changes requiring a flash erase and re-upload.
 
 ## v3.0.1 (2024-12-11)
 
@@ -43,7 +56,7 @@ All notable changes to `homekit-ratgdo` will be documented in this file. This pr
 
 ### Known Issues
 
-* Still testing... Future updates MAY include breaking changes reqiring a flash erase and re-upload.
+* Still testing... Future updates MAY include breaking changes requiring a flash erase and re-upload.
 
 ## v3.0.0 (2024-11-30)
 
@@ -53,5 +66,5 @@ All notable changes to `homekit-ratgdo` will be documented in this file. This pr
 
 ### Known Issues
 
-* THIS IS PRE-RELEASE FIRMWARE for testing purposes. Future updates MAY include breaking changes reqiring a flash erase and re-upload.
+* THIS IS PRE-RELEASE FIRMWARE for testing purposes. Future updates MAY include breaking changes requiring a flash erase and re-upload.
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ When you first add the device to HomeKit a number of accessories are added:
 
 * HomeKit _bridge_ to which all other accessories are attached
 * _garage door_ with door state, obstruction detection and lock. Lock not available with Dry Contact protocol
-* _light_ switch. Not available with Dry Contact protocol
-* _motion_ sensor. Automatically added for doors with wall panels that detect motion. Also can be optionally added and triggered by a button press on the wall pannel and/or triggering the obstruction sensor.
+* _light switch_. Not available with Dry Contact protocol
+* _motion_ sensor. Automatically added for doors with wall panels that detect motion. Also can be optionally added and triggered by a button press on the wall panel and/or triggering the obstruction sensor.
 * Vehicle arriving _motion_ sensor. Only on ratgdo32-disco boards, triggers motion if it detects arrival of a vehicle.
 * Vehicle departing _motion_ sensor. Only on ratgdo32-disco boards, triggers motion if it detects departure of a vehicle.
 * Vehicle presence _occupancy_ sensor. Only on ratgdo32-disco boards, set if the distance sensor detects presence of a vehicle.
+* Parking assist laser _light switch_. Only on ratgdo32-disco boards.
 
 Vehicle arrival and departing sensors are only triggered if vehicle motion is detected within 5 minutes of door opening or closing. The parking assist
 laser is activated for one minute when vehicle arrival is detected.
@@ -368,7 +369,7 @@ select after adding it.
 I get a message [Unable to Add Accessory: The setup code is incorrect.](https://github.com/ratgdo/homekit-ratgdo32/issues/97)
 
 > [!WARNING]
-We have had a number of users that have encountered this error that was a result of running HomeBridge with the Bounjour-HAP mDNS backend. You can find
+We have had a number of users that have encountered this error that was a result of running HomeBridge with the Bonjour-HAP mDNS backend. You can find
 more details in the issue thread, but the short story is to consider changing that backend to Avahi or Ciao.
 
 ### How do I re-pair my ratgdo?

--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -39,6 +39,7 @@ static DEV_Motion *motion;
 static DEV_Motion *arriving;
 static DEV_Motion *departing;
 static DEV_Occupancy *vehicle;
+static DEV_Light *assistLaser;
 
 static bool isPaired = false;
 static bool rebooting = false;
@@ -71,7 +72,6 @@ void wifiCallbackAll(int count)
     }
     // beep on completing startup.
     tone(BEEPER_PIN, 2000, 500);
-    laser.off();
 }
 
 void statusCallback(HS_STATUS status)
@@ -186,6 +186,11 @@ void createVehicleAccessories()
     new SpanAccessory();
     new DEV_Info("Vehicle");
     vehicle = new DEV_Occupancy();
+
+    // Define Light accessory for parking assist laser
+    new SpanAccessory();
+    new DEV_Info("Laser");
+    assistLaser = new DEV_Light(Light_t::ASSIST_LASER);
 }
 
 void enable_service_homekit_vehicle()
@@ -481,17 +486,47 @@ void notify_homekit_light()
     queueSendHelper(light->event_q, e, "light");
 }
 
-DEV_Light::DEV_Light() : Service::LightBulb()
+void notify_homekit_laser(bool on)
 {
-    RINFO(TAG, "Configuring HomeKit Light Service");
+    if (!isPaired || !assistLaser)
+        return;
+
+    GDOEvent e;
+    e.value.b = on;
+    queueSendHelper(assistLaser->event_q, e, "laser");
+}
+
+DEV_Light::DEV_Light(Light_t type) : Service::LightBulb()
+{
+    DEV_Light::type = type;
+    if (type == Light_t::GDO_LIGHT)
+        RINFO(TAG, "Configuring HomeKit Light Service for GDO Light");
+    else if (type == Light_t::ASSIST_LASER)
+        RINFO(TAG, "Configuring HomeKit Light Service for Laser");
     event_q = xQueueCreate(5, sizeof(GDOEvent));
-    on = new Characteristic::On(on->OFF);
+    DEV_Light::on = new Characteristic::On(DEV_Light::on->OFF);
 }
 
 boolean DEV_Light::update()
 {
-    RINFO(TAG, "Turn light %s", on->getNewVal<bool>() ? "on" : "off");
-    set_light(on->getNewVal<bool>());
+    if (this->type == Light_t::GDO_LIGHT)
+    {
+        RINFO(TAG, "Turn light %s", on->getNewVal<bool>() ? "on" : "off");
+        set_light(DEV_Light::on->getNewVal<bool>());
+    }
+    else if (this->type == Light_t::ASSIST_LASER)
+    {
+        if (on->getNewVal<bool>())
+        {
+            RINFO(TAG, "Turn parking assist laser on");
+            laser.on();
+        }
+        else
+        {
+            RINFO(TAG, "Turn parking assist laser off");
+            laser.off();
+        }
+    }
     return true;
 }
 
@@ -501,8 +536,11 @@ void DEV_Light::loop()
     {
         GDOEvent e;
         xQueueReceive(event_q, &e, 0);
-        RINFO(TAG, "Light has turned %s", e.value.b ? "on" : "off");
-        on->setVal(e.value.b);
+        if (this->type == Light_t::GDO_LIGHT)
+            RINFO(TAG, "Light has turned %s", e.value.b ? "on" : "off");
+        else if (this->type == Light_t::ASSIST_LASER)
+            RINFO(TAG, "Parking assist laster has turned %s", e.value.b ? "on" : "off");
+        DEV_Light::on->setVal(e.value.b);
     }
 }
 
@@ -555,7 +593,7 @@ DEV_Motion::DEV_Motion(const char *name) : Service::MotionSensor()
     RINFO(TAG, "Configuring HomeKit Motion Service for %s", name);
     event_q = xQueueCreate(5, sizeof(GDOEvent));
     strlcpy(this->name, name, sizeof(this->name));
-    motion = new Characteristic::MotionDetected(motion->NOT_DETECTED);
+    DEV_Motion::motion = new Characteristic::MotionDetected(motion->NOT_DETECTED);
 }
 
 void DEV_Motion::loop()
@@ -565,7 +603,7 @@ void DEV_Motion::loop()
         GDOEvent e;
         xQueueReceive(event_q, &e, 0);
         RINFO(TAG, "%s %s", name, e.value.b ? "detected" : "reset");
-        motion->setVal(e.value.b);
+        DEV_Motion::motion->setVal(e.value.b);
     }
 }
 
@@ -586,7 +624,7 @@ DEV_Occupancy::DEV_Occupancy() : Service::OccupancySensor()
 {
     RINFO(TAG, "Configuring HomeKit Occupancy Service");
     event_q = xQueueCreate(5, sizeof(GDOEvent));
-    occupied = new Characteristic::OccupancyDetected(occupied->NOT_DETECTED);
+    DEV_Occupancy::occupied = new Characteristic::OccupancyDetected(occupied->NOT_DETECTED);
 }
 
 void DEV_Occupancy::loop()
@@ -596,6 +634,6 @@ void DEV_Occupancy::loop()
         GDOEvent e;
         xQueueReceive(event_q, &e, 0);
         RINFO(TAG, "Vehicle occupancy %s", e.value.b ? "detected" : "reset");
-        occupied->setVal(e.value.b);
+        DEV_Occupancy::occupied->setVal(e.value.b);
     }
 }

--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -316,7 +316,7 @@ DEV_Info::DEV_Info(const char *name) : Service::AccessoryInformation()
 boolean DEV_Info::update()
 {
     RINFO(TAG, "Request to identify accessory, flash LED, etc.");
-    // LED, Laser and Tone calls are all asyncronous.  We will iluminate LED and Laser
+    // LED, Laser and Tone calls are all asynchronous.  We will illuminate LED and Laser
     // for 2 seconds, during which we will play tone.  Function will return after 1.5 seconds.
     led.flash(2000);
     laser.flash(2000);

--- a/src/homekit.h
+++ b/src/homekit.h
@@ -23,6 +23,13 @@
 // RATGDO project includes
 #include "HomeSpan.h"
 
+
+enum Light_t : uint8_t
+{
+    GDO_LIGHT = 1,
+    ASSIST_LASER = 2,
+};
+
 void setup_homekit();
 
 extern void notify_homekit_target_door_state_change();
@@ -37,6 +44,7 @@ extern void notify_homekit_motion();
 extern void notify_homekit_vehicle_occupancy(bool vehicleDetected);
 extern void notify_homekit_vehicle_arriving(bool vehicleArriving);
 extern void notify_homekit_vehicle_departing(bool vehicleDeparting);
+extern void notify_homekit_laser(bool on);
 extern void enable_service_homekit_vehicle();
 
 extern void homekit_unpair();
@@ -78,8 +86,9 @@ struct DEV_Light : Service::LightBulb
     Characteristic::On *on;
 
     QueueHandle_t event_q;
+    Light_t type;
 
-    DEV_Light();
+    DEV_Light(Light_t type = Light_t::GDO_LIGHT);
     boolean update();
     void loop();
 };

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -34,7 +34,7 @@ LED::LED(uint8_t gpio_num, uint8_t state)
     pin = gpio_num;
     activeState = onState = state;
     // off is opposite of on, which can be zero or one.
-    offState = (onState == 1) ? 0 : 1;
+    currentState = offState = (onState == 1) ? 0 : 1;
     idleState = (activeState == 1) ? 0 : 1;
     LEDtimer = Ticker();
     pinMode(pin, OUTPUT);
@@ -43,11 +43,13 @@ LED::LED(uint8_t gpio_num, uint8_t state)
 void LED::on()
 {
     digitalWrite(pin, onState);
+    currentState = onState;
 }
 
 void LED::off()
 {
     digitalWrite(pin, offState);
+    currentState = offState;
 }
 
 void LED::idle()

--- a/src/led.h
+++ b/src/led.h
@@ -29,6 +29,7 @@ private:
     uint8_t offState = 0; // opposite of on
     uint8_t activeState = 1;
     uint8_t idleState = 0; // opposite of active
+    uint8_t currentState = 0;
     Ticker LEDtimer;
 
 public:
@@ -36,6 +37,7 @@ public:
     void on();
     void off();
     void idle();
+    bool state() { return (currentState == onState); };
     void flash(unsigned long ms = FLASH_MS);
     void setIdleState(uint8_t state);
     uint8_t getIdleState() { return idleState; };

--- a/src/ratgdo.cpp
+++ b/src/ratgdo.cpp
@@ -85,7 +85,6 @@ void setup()
 
     // Beep on boot...
     tone(BEEPER_PIN, 1300, 500);
-    laser.on();
     led.on();
 
     load_all_config_settings();

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -218,6 +218,7 @@ function setElementsFromStatus(status) {
             case "distanceSensor":
                 document.getElementById("vehicleRow").style.display = (value) ? "table-row" : "none";
                 document.getElementById("vehicleSetting").style.display = (value) ? "table-row" : "none";
+                document.getElementById("laserButton").style.display = (value) ? "inline-block" : "none";
                 break;
             case "vehicleThreshold":
                 document.getElementById(key).value = value;
@@ -297,6 +298,21 @@ function setElementsFromStatus(status) {
                 break;
             case "motionTriggers":
                 setMotionTriggers(value);
+                break;
+            case "garageLightOn":
+                document.getElementById(key).innerHTML = value;
+                document.getElementById("lightButton").value = (value == false) ? "Light On" : "Light Off";
+                break;
+            case "garageDoorState":
+                document.getElementById(key).innerHTML = value;
+                document.getElementById("doorButton").value = (value == "Closed") ? "Open Door" : "Close Door";
+                break;
+            case "garageLockState":
+                document.getElementById(key).innerHTML = value;
+                document.getElementById("lockButton").value = (value == "Unsecured") ? "Lock Door" : "Unlock Door";
+                break;
+            case "assistLaser":
+                document.getElementById("laserButton").value = (value == false) ? "Laser On" : "Laser Off";
                 break;
             case "freeIramHeap":
                 // Unused... remove this case statement when/if we add to html.

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -104,7 +104,7 @@
           </p>
         </div>
         <div class="fullwidth" style="padding: 0px;">
-          <div class="serverstatus" style="padding: 0px; padding-bottom: 5px;">
+          <div class="serverstatus" style="padding: 0px; padding-bottom: 5px; display: flex; justify-content: space-evenly;">
             <input type="button" value="Reboot RATGDO" onclick="rebootRATGDO(true)">
             <input type="button" value="Firmware Update" onclick="showUpdateDialog()">
           </div>
@@ -263,14 +263,6 @@
                   <label for="motionMotion">Motion</label>
                   <input type="checkbox" id="motionObstruction" name="motionObstruction" value="no">
                   <label for="motionObstruction">Obstruction</label>
-                  <!--
-                  <input type="checkbox" id="motionLight" name="motionLight" value="no">
-                  <label for="motionLight">Light</label>
-                  <input type="checkbox" id="motionDoor" name="motionDoor" value="no">
-                  <label for="motionDoor">Door</label>
-                  <input type="checkbox" id="motionLock" name="motionLock" value="no">
-                  <label for="motionLock">Lock</label>
-                  -->
                   <input type="checkbox" id="motionWallPanel" name="motionWallPanel" value="no">
                   <label for="motionWallPanel">Wall Panel</label>
                 </td>

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -132,7 +132,7 @@
               <td>Motion:</td>
               <td id="garageMotion"></td>
             </tr>
-            <tr id="vehicleRow">
+            <tr id="vehicleRow" style="display:none;">
               <td>Vehicle:</td>
               <td id="vehicleStatus"></td>
               <td>Distance:</td>
@@ -141,13 +141,15 @@
           </table>
         </div>
         <div id="GDOcontrols" class="fullwidth"
-          style="padding-left: 0px; padding-right: 0px; display: flex; justify-content: space-between;">
-          <input type="button" value="Light On" onclick="setGDO('garageLightOn', '1')">
-          <input type="button" value="Light Off" onclick="setGDO('garageLightOn', '0')">
-          <input type="button" value="Door Open" onclick="setGDO('garageDoorState', '1')">
-          <input type="button" value="Door Close" onclick="setGDO('garageDoorState', '0')">
-          <input type="button" value="Door Lock" onclick="setGDO('garageLockState', '1')">
-          <input type="button" value="Door Unlock" onclick="setGDO('garageLockState', '0')">
+          style="padding-left: 20px; padding-right: 20px; display: flex; justify-content: space-evenly;">
+          <input type="button" id="lightButton" value="Light On"
+            onclick="setGDO('garageLightOn', (event.target.value === 'Light On') ? '1' : '0');">
+          <input type="button" id="doorButton" value="Open Door"
+            onclick="setGDO('garageDoorState', (event.target.value === 'Open Door') ? '1' : '0');">
+          <input type="button" id="lockButton" value="Lock Door"
+            onclick="setGDO('garageLockState', (event.target.value === 'Lock Door') ? '1' : '0');">
+          <input type="button" id="laserButton" value="Laser On" style="display:none;"
+            onclick="setGDO('assistLaser', (event.target.value === 'Laser On') ? '1' : '0');">
         </div>
       </div>
       <!-- Settings section of page ------------------------------------------------------------------>
@@ -273,7 +275,7 @@
                   <label for="motionWallPanel">Wall Panel</label>
                 </td>
               </tr>
-              <tr id="vehicleSetting">
+              <tr id="vehicleSetting" style="display:none;">
                 <td class="label">Vehicle Distance:</td>
                 <td>&nbsp;
                   <input type="range" min="5" max="300" value="180" id="vehicleThreshold" name="vehicleThreshold"


### PR DESCRIPTION
Adds a HomeKit light switch, and a button on the web page, for parking assist laser.

To avoid clutter on the web page I changed from having two separate buttons (light on / light off, door open / door close, etc) to one button that acts as on/off,  open/close, etc. based on current state.  If I didn't do this I would have had eight buttons on the web page, this reduces it to four (three on non-disco boards).

I also installed a spell check extension in VScode, it found a number of typos!