### PR TITLE
Enable IPv6 

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -239,11 +239,18 @@ userSettings::userSettings()
         {cfg_wifiChanged, {true, true, false, NULL}},
         {cfg_wifiPower, {true, true, WIFI_POWER_MAX, helperWiFiPower}}, // call fn to set reboot only if setting changed
         {cfg_wifiPhyMode, {true, true, 0, helperWiFiPhyMode}},          // call fn to set reboot only if setting changed
+
+        // IPv4
         {cfg_staticIP, {true, true, false, NULL}},
         {cfg_localIP, {true, true, "0.0.0.0", NULL}},
         {cfg_subnetMask, {true, true, "0.0.0.0", NULL}},
         {cfg_gatewayIP, {true, true, "0.0.0.0", NULL}},
         {cfg_nameserverIP, {true, true, "0.0.0.0", NULL}},
+
+        // IPv6
+        {cfg_linkLocalIPv6, {true, true, "::", NULL}},
+        {cfg_globalIPv6, {true, true, "::", NULL}},
+
         {cfg_passwordRequired, {false, false, false, NULL}},
         {cfg_wwwUsername, {false, false, "admin", NULL}},
         //  Credentials are MD5 Hash... server.credentialHash(username, realm, "password");

--- a/src/config.h
+++ b/src/config.h
@@ -45,11 +45,18 @@ constexpr char cfg_deviceName[] = "deviceName";
 constexpr char cfg_wifiChanged[] = "wifiChanged";
 constexpr char cfg_wifiPower[] = "wifiPower";
 constexpr char cfg_wifiPhyMode[] = "wifiPhyMode";
+
+// IPv4
 constexpr char cfg_staticIP[] = "staticIP";
 constexpr char cfg_localIP[] = "localIP";
 constexpr char cfg_subnetMask[] = "subnetMask";
 constexpr char cfg_gatewayIP[] = "gatewayIP";
 constexpr char cfg_nameserverIP[] = "nameserverIP";
+
+// IPv6
+constexpr char cfg_linkLocalIPv6[] = "linkLocalIPv6";
+constexpr char cfg_globalIPv6[] = "globalIPv6";
+
 constexpr char cfg_passwordRequired[] = "passwordRequired";
 constexpr char cfg_wwwUsername[] = "wwwUsername";
 constexpr char cfg_wwwCredentials[] = "wwwCredentials";
@@ -124,10 +131,17 @@ public:
     int getWifiPower() { return std::get<int>(get(cfg_wifiPower)); };
     int getWifiPhyMode() { return std::get<int>(get(cfg_wifiPhyMode)); };
     bool getStaticIP() { return std::get<bool>(get(cfg_staticIP)); };
+
+    // IPv4
     std::string getLocalIP() { return std::get<std::string>(get(cfg_localIP)); };
     std::string getSubnetMask() { return std::get<std::string>(get(cfg_subnetMask)); };
     std::string getGatewayIP() { return std::get<std::string>(get(cfg_gatewayIP)); };
     std::string getNameserverIP() { return std::get<std::string>(get(cfg_nameserverIP)); };
+
+    // IPv6
+    std::string getLinkLocalIPv6() { return std::get<std::string>(get(cfg_linkLocalIPv6)); };
+    std::string getGlobalIPv6() { return std::get<std::string>(get(cfg_globalIPv6)); };
+
     bool getPasswordRequired() { return std::get<bool>(get(cfg_passwordRequired)); };
     std::string getwwwUsername() { return std::get<std::string>(get(cfg_wwwUsername)); };
     std::string getwwwCredentials() { return std::get<std::string>(get(cfg_wwwCredentials)); };

--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -60,6 +60,7 @@ void wifiBegin(const char *ssid, const char *pw)
     ESP_LOGI(TAG, "Wifi begin for SSID: %s", ssid);
     WiFi.setSleep(WIFI_PS_NONE); // Improves performance, at cost of power consumption
     WiFi.hostname((const char *)device_name_rfc952);
+    WiFi.enableIPv6(); // Enable IPv6 support
     if (userConfig->getStaticIP())
     {
         IPAddress ip;
@@ -88,12 +89,23 @@ void connectionCallback(int count)
     if (rebooting)
         return;
 
-    ESP_LOGI(TAG, "WiFi established, count: %d, IP: %s, Mask: %s, Gateway: %s, DNS: %s", count, WiFi.localIP().toString().c_str(),
-             WiFi.subnetMask().toString().c_str(), WiFi.gatewayIP().toString().c_str(), WiFi.dnsIP().toString().c_str());
+    ESP_LOGI(TAG, "WiFi established, count: %d, IP: %s, Mask: %s, Gateway: %s, DNS: %s Link_IPv6: %s, Global_IPv6: %s",
+        count,
+        WiFi.localIP().toString().c_str(),
+        WiFi.subnetMask().toString().c_str(),
+        WiFi.gatewayIP().toString().c_str(),
+        WiFi.dnsIP().toString().c_str(),
+        WiFi.linkLocalIPv6().toString().c_str(),
+        WiFi.globalIPv6().toString().c_str());
+
     userConfig->set(cfg_localIP, WiFi.localIP().toString().c_str());
     userConfig->set(cfg_gatewayIP, WiFi.gatewayIP().toString().c_str());
     userConfig->set(cfg_subnetMask, WiFi.subnetMask().toString().c_str());
     userConfig->set(cfg_nameserverIP, WiFi.dnsIP().toString().c_str());
+
+    userConfig->set(cfg_linkLocalIPv6, WiFi.linkLocalIPv6().toString().c_str());
+    userConfig->set(cfg_globalIPv6, WiFi.globalIPv6().toString().c_str());
+
     // With WiFi connected, we can now initialize the rest of our app.
     if (!softAPmode)
     {

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -447,10 +447,16 @@ void handle_status()
     ADD_STR(json, "firmwareVersion", std::string(AUTO_VERSION).c_str());
     // TODO find and show HomeKit accessory ID... ADD_STR(json, "accessoryID", accessoryID);
     // TODO monitor number of HomeKit "clients" connected... ADD_INT(json, "clients", clientCount);
+    // IPv4
     ADD_STR(json, cfg_localIP, userConfig->getLocalIP().c_str());
     ADD_STR(json, cfg_subnetMask, userConfig->getSubnetMask().c_str());
     ADD_STR(json, cfg_gatewayIP, userConfig->getGatewayIP().c_str());
     ADD_STR(json, cfg_nameserverIP, userConfig->getNameserverIP().c_str());
+
+    // IPv6
+    ADD_STR(json, cfg_linkLocalIPv6, userConfig->getLinkLocalIPv6().c_str());
+    ADD_STR(json, cfg_globalIPv6, userConfig->getGlobalIPv6().c_str());
+
     ADD_STR(json, "macAddress", Network.macAddress().c_str());
     ADD_STR(json, "wifiSSID", WiFi.SSID().c_str());
     ADD_STR(json, "wifiRSSI", (std::to_string(WiFi.RSSI()) + " dBm, Channel " + std::to_string(WiFi.channel())).c_str());

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -327,7 +327,12 @@ function setElementsFromStatus(status) {
             */
             case "localIP":
                 document.getElementById(key).innerHTML = value;
-                document.getElementById("IPaddress").placeholder = value;
+                break;
+            case "linkLocalIPv6":
+                document.getElementById(key).innerHTML = value;
+                break;
+            case "globalIPv6":
+                document.getElementById(key).innerHTML = value;
                 break;
             case "subnetMask":
                 document.getElementById(key).innerHTML = value;
@@ -1103,7 +1108,7 @@ function swipeCheck() {
     }
 }
 function isPullDown(dY, dX) {
-    // methods of checking slope, length, direction of line created by swipe action 
+    // methods of checking slope, length, direction of line created by swipe action
     return dY < 0 && (
         (Math.abs(dX) <= 100 && Math.abs(dY) >= 300)
         || (Math.abs(dX) / Math.abs(dY) <= 0.3 && dY >= 60)

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -75,6 +75,14 @@
               <td id="macAddress"></td>
             </tr>
             <tr>
+              <td>Link Local IPv6:</td>
+              <td id="linkLocalIPv6"></td>
+            </tr>
+            <tr>
+              <td>Global IPv6:</td>
+              <td id="globalIPv6"></td>
+            </tr>
+            <tr>
               <td>IP Address:</td>
               <td id="localIP"></td>
             </tr>

--- a/src/www/style.css
+++ b/src/www/style.css
@@ -1,6 +1,6 @@
 /*************************************************************
  * Stylesheet for RATDGO web status page
- * 
+ *
  * Copyright (c) 2023-25 David Kerr, https://github.com/dkerr64
  *
  *************************************************************/
@@ -129,7 +129,7 @@ div.qrcode {
 
 div.fullwidth {
     width: 100%;
-    max-width: 800px;
+    max-width: 1000px;
     overflow: hidden;
     position: relative;
     border-bottom-style: solid;
@@ -144,7 +144,7 @@ div.fullwidth {
 
 div.header {
     width: 100%;
-    max-width: 800px;
+    max-width: 1000px;
     overflow: hidden;
     position: relative;
     border-bottom-style: solid;
@@ -156,7 +156,7 @@ div.header {
 
 div.fullpage {
     margin: auto;
-    max-width: 800px;
+    max-width: 1000px;
     height: auto;
     overflow: hidden;
     position: relative;


### PR DESCRIPTION
This PR enables IPv6 within the homekit-ratgdo32.   The ratgdo is the only device in my network that doesn't support IPv6 so I decided to change that.  

Let me know if this isn't the direction you want to go with the firmware, if something doesn't look right, and all other concerns and I'll be glad to correct or answer them. 

## Changes
- Enables IPv6 using `WiFi.enableIPv6`
- Adding configs for link local and global IPv6 addresses
- Updating logging for wifi connection
- Adding IPv6 addresses to status response
- Adding IPv6 addresses to status page
- Widened Status page to accommodate longer IPv6 addresses

## Testing
- Compiled and running on my personal ratgdo32 in a dual stack (IPv4 + IPv6) network
- All commands still work over IPv6 & IPv4
  - Homekit functions
  - Firmware update
  - Web commands
  - Web system Logs
- Web page is accessible using IPv4, Link Local IPv6, & Global IPv6

## Screenshots

<img width="1416" alt="Screenshot 2025-06-01 at 8 50 19 PM" src="https://github.com/user-attachments/assets/a7f0a962-0954-4967-aeaf-45f59249db9a" />
