### PR TITLE
Make IPv6 optional and default to disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 All notable changes to `homekit-ratgdo32` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v3.1.11 (2025-06-13)
+
+### What's Changed
+
+* Feature: Make IPv6 optional, disabled by default.
+
 ## v3.1.10 (2025-06-08)
 
 ### What's Changed

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "homekit-ratgdo",
-  "version": "v3.1.10",
+  "version": "v3.1.11",
   "new_install_prompt_erase": true,
   "new_install_improv_wait_time": 60,
   "builds": [

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -276,6 +276,7 @@ userSettings::userSettings()
         {cfg_useSWserial, {true, false, true, helperUseSWserial}}, // call fn to shut down GDO before switch
         {cfg_obstFromStatus, {true, false, true, NULL}},
         {cfg_occupancyDuration, {false, false, 0, helperOccupancyDuration}}, // call fn to enable/disable HomeKit accessories
+        {cfg_enableIPv6, {true, false, false, NULL}},
     };
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -78,6 +78,7 @@ constexpr char cfg_dcDebounceDuration[] = "dcDebounceDuration";
 constexpr char cfg_useSWserial[] = "useSWserial";
 constexpr char cfg_obstFromStatus[] = "obstFromStatus";
 constexpr char cfg_occupancyDuration[] = "occupancyDuration";
+constexpr char cfg_enableIPv6[] = "enableIPv6";
 
 constexpr char nvram_messageLog[] = "messageLog";
 constexpr char nvram_id_code[] = "id_code";
@@ -156,6 +157,7 @@ public:
     bool getUseSWserial() { return std::get<bool>(get(cfg_useSWserial)); };
     bool getObstFromStatus() { return std::get<bool>(get(cfg_obstFromStatus)); };
     int getOccupancyDuration() { return std::get<int>(get(cfg_occupancyDuration)); };
+    bool getEnableIPv6() { return std::get<bool>(get(cfg_enableIPv6)); };
 };
 extern userSettings *userConfig;
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -123,7 +123,7 @@ char *make_rfc952(char *dest, const char *src, int size)
     int i = 0;
     while (i <= std::min(24, size - 1) && src[i] != 0)
     {
-        dest[i] = (std::isalnum((int)src[i]) || src[i] == '.'  ) ? src[i] : '-';
+        dest[i] = (std::isalnum((int)src[i]) || src[i] == '.') ? src[i] : '-';
         i++;
     }
     // remove dashes and periods from end of name
@@ -162,6 +162,7 @@ void load_all_config_settings()
     ESP_LOGI(TAG, "   subnetMask:          %s", userConfig->getSubnetMask().c_str());
     ESP_LOGI(TAG, "   gatewayIP:           %s", userConfig->getGatewayIP().c_str());
     ESP_LOGI(TAG, "   nameserverIP:        %s", userConfig->getNameserverIP().c_str());
+    ESP_LOGI(TAG, "   enableIPv6:          %s", userConfig->getEnableIPv6() ? "true" : "false");
     ESP_LOGI(TAG, "   wwwPWrequired:       %s", userConfig->getPasswordRequired() ? "true" : "false");
     ESP_LOGI(TAG, "   wwwUsername:         %s", userConfig->getwwwUsername().c_str());
     ESP_LOGI(TAG, "   wwwCredentials:      %s", userConfig->getwwwCredentials().c_str());

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -452,10 +452,8 @@ void handle_status()
     ADD_STR(json, cfg_subnetMask, userConfig->getSubnetMask().c_str());
     ADD_STR(json, cfg_gatewayIP, userConfig->getGatewayIP().c_str());
     ADD_STR(json, cfg_nameserverIP, userConfig->getNameserverIP().c_str());
-
-    // IPv6
+    ADD_BOOL(json, cfg_enableIPv6, userConfig->getEnableIPv6());
     ADD_STR(json, "ipv6Addresses", ipv6_addresses);
-
     ADD_STR(json, "macAddress", Network.macAddress().c_str());
     ADD_STR(json, "wifiSSID", WiFi.SSID().c_str());
     ADD_STR(json, "wifiRSSI", (std::to_string(WiFi.RSSI()) + " dBm, Channel " + std::to_string(WiFi.channel())).c_str());

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -371,6 +371,10 @@ function setElementsFromStatus(status) {
                 document.getElementById(key).checked = value;
                 document.getElementById("timeZoneTable").style.display = (value) ? "table" : "none";
                 break;
+            case "enableIPv6":
+                document.getElementById(key).checked = value;
+                document.getElementById("ipv6Row").style.display = (value) ? "table-row" : "none";
+                break;
             case "timeZone":
                 if (value.indexOf(';') < 0) {
                     // No semicolon so POSIX time zone info is missing, tell server the time zone (async);
@@ -979,13 +983,14 @@ async function saveSettings() {
     let nameserverIP = document.getElementById("IPnameserver").value.substring(0, 15);
     if (nameserverIP.length == 0) nameserverIP = serverStatus.nameserverIP;
     const enableNTP = (document.getElementById("enableNTP").checked) ? '1' : '0';
+    const enableIPv6 = (document.getElementById("enableIPv6").checked) ? '1' : '0';
     const list = document.getElementById("timeZoneInput");
     const timeZone = list.options[list.selectedIndex].text + ';' + list.options[list.selectedIndex].value;
 
     // check IP addresses valid
     const regexIPv4 = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/i;
 
-    if (!(regexIPv4.test(localIP) && regexIPv4.test(subnetMask) && regexIPv4.test(gatewayIP) && regexIPv4.test(nameserverIP) &&  regexIPv4.test(syslogIP))) {
+    if (!(regexIPv4.test(localIP) && regexIPv4.test(subnetMask) && regexIPv4.test(gatewayIP) && regexIPv4.test(nameserverIP) && regexIPv4.test(syslogIP))) {
         console.error(`Invalid IP address(s): ${localIP} / ${subnetMask} / ${gatewayIP} / ${nameserverIP} / ${syslogIP}`);
         alert(`Invalid IP address(s): ${localIP} / ${subnetMask} / ${gatewayIP} / ${nameserverIP} / ${syslogIP}`);
         return;
@@ -1017,6 +1022,7 @@ async function saveSettings() {
         "gatewayIP", gatewayIP,
         "nameserverIP", nameserverIP,
         "enableNTP", enableNTP,
+        "enableIPv6", enableIPv6,
         "timeZone", timeZone,
         "syslogEn", syslogEn,
         "syslogIP", syslogIP,

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -74,7 +74,7 @@
               <td>MAC&nbsp;Address:</td>
               <td id="macAddress"></td>
             </tr>
-            <tr>
+            <tr id="ipv6Row" style="display:none;">
               <td>IPv6&nbsp;Address:</td>
               <td id="ipv6Addresses" style="white-space:pre;"></td>
             </tr>
@@ -327,8 +327,8 @@
                     <tr>
                       <td class="label">Occupancy&nbsp;Duration:</td>
                       <td>&nbsp;
-                        <input type="range" min="0" max="32" value="0" id="occupancyDuration"
-                          name="occupancyDuration" class="slider" style="width:100px;">
+                        <input type="range" min="0" max="32" value="0" id="occupancyDuration" name="occupancyDuration"
+                          class="slider" style="width:100px;">
                         <span style="vertical-align: middle;"><span id="occupancyValue"></span>&nbsp;Mins</span>
                       </td>
                     </tr>
@@ -462,7 +462,14 @@
               </tr>
               -->
               <tr>
-                <td class="label">Static IP:</td>
+                <td class="label">Enable IPv6:</td>
+                <td>&nbsp;
+                  <input type="checkbox" id="enableIPv6" name="enableIPv6" value="no">
+                  <label for="enableIPv6">Experimental, for test only.</label>
+                </td>
+              </tr>
+              <tr>
+                <td class="label">Static IPv4:</td>
                 <td>&nbsp;
                   <input type="checkbox" id="staticIP" name="staticIP" value="no" onchange="toggleStaticIP()">
                 </td>

--- a/src/www/status.json
+++ b/src/www/status.json
@@ -11,6 +11,7 @@
   "gatewayIP": "192.168.99.1",
   "nameserverIP": "192.168.99.1",
   "ipv6Addresses": "fe80::23:45ff:feab:cdef,fd00:abcd:1234:5678:23:45ff:feab:cdef,2000:abcd:1234:5678:23:45ff:feab:cdef",
+  "enableIPv6": true,
   "macAddress": "02:23:45:AB:CD:EF",
   "syslogEn": true,
   "syslogIP": "192.168.99.2",


### PR DESCRIPTION
There are problems in underlying HomeSpan code that make IPv6 not work... and in some cases cause a loop of network connection.  So, I am disabling IPv6 by default but adding a user setting to facilitate testing.