### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 All notable changes to `homekit-ratgdo32` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v3.3.5 (2025-09-28)
+
+### What's Changed
+
+* Bugfix: Add error handling for a blank SSID... force boot into Soft AP mode, https://github.com/ratgdo/homekit-ratgdo/issues/295
+* Bugfix: Buffer overrun that caused Improv setup to fail, https://github.com/ratgdo/homekit-ratgdo/issues/298
+* Bugfix: Aog messages that are truncated for exceeding buffer size not null terminated
+* Other: Add simple serial console CLI (when HomeSpan CLI disabled) to allow setting debug level, displaying saved logs and request reboot.
+
+### Known Issues
+
+* Sec+ 1.0 doors with digital wall panel (e.g. 889LM) sometimes do not close after a time-to-close delay. Please watch your door to make sure it closes after TTC delay.
+* Sec+ 1.0 doors with "0x37" digital wall panel (e.g. 389LM) not working.
+
 ## v3.3.4 (2025-09-27)
 
 ### What's Changed

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "homekit-ratgdo",
-  "version": "v3.3.4",
+  "version": "v3.3.5",
   "new_install_prompt_erase": true,
   "new_install_improv_wait_time": 60,
   "builds": [
@@ -8,11 +8,11 @@
       "chipFamily": "ESP32",
       "parts": [
         {
-          "path": "firmware/homekit-ratgdo32-v3.3.4.bootloader.bin",
+          "path": "firmware/homekit-ratgdo32-v3.3.5.bootloader.bin",
           "offset": 4096
         },
         {
-          "path": "firmware/homekit-ratgdo32-v3.3.4.partitions.bin",
+          "path": "firmware/homekit-ratgdo32-v3.3.5.partitions.bin",
           "offset": 32768
         },
         {
@@ -20,7 +20,7 @@
           "offset": 57344
         },
         {
-          "path": "firmware/homekit-ratgdo32-v3.3.4.firmware.bin",
+          "path": "firmware/homekit-ratgdo32-v3.3.5.firmware.bin",
           "offset": 65536
         }
       ]

--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -273,6 +273,15 @@ char ipv6_addresses[LWIP_IPV6_NUM_ADDRESSES * IP6ADDR_STRLEN_MAX] = {0};
  */
 void wifiBegin(const char *ssid, const char *pw)
 {
+    if (strEmptyOrSpaces(ssid))
+    {
+        ESP_LOGE(TAG, "ERROR: Invalid SSID value (%s) boot into soft access point mode", ssid);
+        userConfig->set(cfg_softAPmode, true);
+        ESP8266_SAVE_CONFIG();
+        sync_and_restart();
+        return;
+    }
+
     ESP_LOGI(TAG, "Wifi begin for SSID: %s", ssid);
     WiFi.setSleep(WIFI_PS_NONE); // Improves performance, at cost of power consumption
     WiFi.hostname(const_cast<char *>(device_name_rfc952));

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -46,6 +46,13 @@ WiFiUDP syslog;
 bool suppressSerialLog = false;
 esp_log_level_t logLevel = ESP_LOG_VERBOSE;
 
+#define SERIAL_PRINT(x)         \
+    do                          \
+    {                           \
+        if (!suppressSerialLog) \
+            Serial.print(x);    \
+    } while (0)
+
 char *toHHMMSSmmm(_millis_t t)
 {
     uint32_t secs = t / 1000;
@@ -229,8 +236,7 @@ void LOG::logToBuffer(const char *fmt, va_list args)
     }
 
     //  print line to the serial port
-    if (!suppressSerialLog)
-        Serial.print(lineBuffer);
+    SERIAL_PRINT(lineBuffer);
 
     // copy the line into the message save buffer
     size_t len = strlen(lineBuffer);
@@ -389,7 +395,7 @@ void LOG::saveMessageLog()
 #ifdef ESP8266
 void LOG::printSavedLog(File file, Print &outputDev, bool slow)
 {
-    Serial.print("Send saved file.");
+    SERIAL_PRINT("Send saved file.");
     if (file && file.size() > 0)
     {
         size_t num = LINE_BUFFER_SIZE;
@@ -399,7 +405,7 @@ void LOG::printSavedLog(File file, Print &outputDev, bool slow)
         {
             num = file.read(reinterpret_cast<uint8_t *>(lineBuffer), LINE_BUFFER_SIZE);
             // Progress dot dot dot
-            Serial.print(".");
+            SERIAL_PRINT(".");
             YIELD();
             outputDev.write(lineBuffer, num);
             if (slow && (count += num) > TCP_SND_BUF / 2)
@@ -413,7 +419,7 @@ void LOG::printSavedLog(File file, Print &outputDev, bool slow)
         outputDev.print("\n");
         outputDev.flush();
     }
-    Serial.print("\n");
+    SERIAL_PRINT("\n");
 }
 #endif
 
@@ -463,14 +469,14 @@ void LOG::printMessageLog(Print &outputDev, bool slow)
         // On slow output devices (e.g. network), chunk up to protect against buffer overflow
         size_t CHUNK = (slow) ? TCP_SND_BUF / 2 : sizeof(msgBuffer->buffer);
         size_t chunk;
-        Serial.print("Send message log.");
+        SERIAL_PRINT("Send message log.");
         if (msgBuffer->wrapped != 0)
         {
             while (len)
             {
                 chunk = std::min(len, CHUNK);
                 // Progress dot dot dot
-                Serial.print(".");
+                SERIAL_PRINT(".");
                 YIELD();
                 outputDev.write(&msgBuffer->buffer[start], chunk);
                 if (slow)
@@ -485,14 +491,14 @@ void LOG::printMessageLog(Print &outputDev, bool slow)
         {
             chunk = std::min(len, CHUNK);
             // Progress dot dot dot
-            Serial.print(".");
+            SERIAL_PRINT(".");
             YIELD();
             outputDev.write(&msgBuffer->buffer[start], chunk);
             outputDev.flush();
             len -= chunk;
             start += chunk;
         }
-        Serial.print("\n");
+        SERIAL_PRINT("\n");
     }
     GIVE_MUTEX();
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -233,6 +233,9 @@ void LOG::logToBuffer(const char *fmt, va_list args)
         int32_t max = LINE_BUFFER_SIZE - ((int32_t)(endptr - lineBuffer) + diff);
         memmove(endptr + diff, endptr, max);
         memcpy(numptr, ts, timestrlen);
+        // Make sure we always end in a newline/null... which can get missed if we truncated the log message
+        lineBuffer[LINE_BUFFER_SIZE - 2] = '\n';
+        lineBuffer[LINE_BUFFER_SIZE - 1] = 0;
     }
 
     //  print line to the serial port

--- a/src/provision.cpp
+++ b/src/provision.cpp
@@ -240,6 +240,17 @@ bool onCommandCallback(improv::ImprovCommand cmd)
 
     case improv::Command::GET_DEVICE_INFO:
     {
+#ifdef ESP8266
+        std::vector<std::string> infos = {
+            // Firmware name
+            "HomeKit-ratgdo",
+            // Firmware version
+            AUTO_VERSION,
+            // Hardware chip/variant
+            "ESP8266",
+            // Device name
+            "Ratgdo"};
+#else
         std::vector<std::string> infos = {
             // Firmware name
             "HomeKit-ratgdo32",
@@ -249,6 +260,7 @@ bool onCommandCallback(improv::ImprovCommand cmd)
             "ESP32",
             // Device name
             "Ratgdo32"};
+#endif
         std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_DEVICE_INFO, infos, false);
         send_response(data);
         break;

--- a/src/ratgdo.cpp
+++ b/src/ratgdo.cpp
@@ -262,9 +262,7 @@ void loop()
 #ifdef RATGDO32_DISCO
     vehicle_loop();
 #endif
-    YIELD(); // Wrap web loop in yield's as handling web requests could be slow.
     web_loop();
-    YIELD();
     improv_loop();
     soft_ap_loop();
     service_timer_loop();

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -94,6 +94,23 @@ void time_is_set(struct timeval *tv)
 }
 #endif
 
+bool strEmptyOrSpaces(const char *str)
+{
+    if (str == NULL)
+    {
+        return true; // Consider NULL as empty
+    }
+    // Iterate through the string
+    for (int i = 0; str[i] != '\0'; i++)
+    {
+        if (!isspace((unsigned char)str[i]))
+        {
+            return false; // Found a non-whitespace character
+        }
+    }
+    return true; // All characters were whitespace or the string was empty
+}
+
 char *timeString(time_t reqTime, bool syslog)
 {
     static char tBuffer[32];

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -94,3 +94,4 @@ extern motionTriggersUnion motionTriggers;
 extern void load_all_config_settings();
 extern void sync_and_restart();
 extern char *make_rfc952(char *dest, const char *src, int size);
+extern bool strEmptyOrSpaces(const char *str);

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -984,6 +984,8 @@ bool helperFactoryReset(const std::string &key, const char *value, configSetting
 #ifdef ESP8266
     userConfig->erase();
     reset_door();
+    WiFi.disconnect();
+    ESP.eraseConfig();
     sync_and_restart();
 #else
     ESP_LOGI(TAG, "System boot time: %s", timeString(lastRebootAt));


### PR DESCRIPTION
### What's Changed

* Bugfix: Add error handling for a blank SSID... force boot into Soft AP mode, https://github.com/ratgdo/homekit-ratgdo/issues/295
* Bugfix: Buffer overrun that caused Improv setup to fail, https://github.com/ratgdo/homekit-ratgdo/issues/298
* Bugfix: Aog messages that are truncated for exceeding buffer size not null terminated
* Other: Add simple serial console CLI (when HomeSpan CLI disabled) to allow setting debug level, displaying saved logs and request reboot.

### Known Issues

* Sec+ 1.0 doors with digital wall panel (e.g. 889LM) sometimes do not close after a time-to-close delay. Please watch your door to make sure it closes after TTC delay.
* Sec+ 1.0 doors with "0x37" digital wall panel (e.g. 398LM) not working.