### PR TITLE
Added toggles to disable homekit light and motion accessories

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -296,6 +296,24 @@ bool helperHomeSpanCLI(const std::string &key, const char *value, configSetting 
         setup_improv();
     return true;
 }
+
+// Forward declarations for HomeKit accessory enable/disable functions
+extern bool enable_service_homekit_light(bool enable);
+extern bool enable_service_homekit_motion_sensor(bool enable);
+
+bool helperLightHomeKit(const std::string &key, const char *value, configSetting *action)
+{
+    userConfig->set(key, value);
+    enable_service_homekit_light(userConfig->getLightHomeKit());
+    return true;
+}
+
+bool helperMotionHomeKit(const std::string &key, const char *value, configSetting *action)
+{
+    userConfig->set(key, value);
+    enable_service_homekit_motion_sensor(userConfig->getMotionHomeKit());
+    return true;
+}
 #endif // ESP32
 
 /****************************************************************************
@@ -385,6 +403,8 @@ userSettings::userSettings()
         {cfg_occupancyDuration, {false, false, 0, helperOccupancyDuration}}, // call fn to enable/disable HomeKit accessories
         {cfg_enableIPv6, {true, false, false, NULL}},
         {cfg_homespanCLI, {false, false, false, helperHomeSpanCLI}}, // call fn to enable/disable HomeSpan CLI and Improv
+        {cfg_lightHomeKit, {false, false, true, helperLightHomeKit}},   // call fn to enable/disable HomeKit light accessory (default: enabled)
+        {cfg_motionHomeKit, {false, false, true, helperMotionHomeKit}}, // call fn to enable/disable HomeKit motion accessory (default: enabled)
 #endif
     };
     IRAM_END(TAG);

--- a/src/config.h
+++ b/src/config.h
@@ -98,6 +98,8 @@ constexpr char cfg_assistDuration[] PROGMEM = "assistDuration";
 constexpr char cfg_occupancyDuration[] PROGMEM = "occupancyDuration";
 constexpr char cfg_enableIPv6[] PROGMEM = "enableIPv6";
 constexpr char cfg_homespanCLI[] PROGMEM = "homespanCLI";
+constexpr char cfg_lightHomeKit[] PROGMEM = "lightHomeKit";
+constexpr char cfg_motionHomeKit[] PROGMEM = "motionHomeKit";
 #endif
 
 constexpr char nvram_id_code[] PROGMEM = "id_code";
@@ -202,6 +204,8 @@ public:
     uint32_t getOccupancyDuration() { return std::get<int>(get(cfg_occupancyDuration)); };
     bool getEnableIPv6() { return std::get<bool>(get(cfg_enableIPv6)); };
     bool getEnableHomeSpanCLI() { return std::get<bool>(get(cfg_homespanCLI)); };
+    bool getLightHomeKit() { return std::get<bool>(get(cfg_lightHomeKit)); };
+    bool getMotionHomeKit() { return std::get<bool>(get(cfg_motionHomeKit)); };
 #endif
 };
 extern userSettings *userConfig;

--- a/src/homekit.h
+++ b/src/homekit.h
@@ -62,6 +62,8 @@ extern void enable_service_homekit_vehicle(bool enable);
 extern bool enable_service_homekit_laser(bool enable);
 extern bool enable_service_homekit_room_occupancy(bool enable);
 extern void notify_homekit_room_occupancy(bool occupied);
+extern bool enable_service_homekit_light(bool enable);
+extern bool enable_service_homekit_motion_sensor(bool enable);
 
 extern void homekit_unpair();
 extern bool homekit_is_paired();

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -836,6 +836,8 @@ void build_status_json(char *json)
     JSON_ADD_INT(cfg_assistDuration, userConfig->getAssistDuration());
 #endif
     JSON_ADD_BOOL(cfg_homespanCLI, userConfig->getEnableHomeSpanCLI());
+    JSON_ADD_BOOL(cfg_lightHomeKit, userConfig->getLightHomeKit());
+    JSON_ADD_BOOL(cfg_motionHomeKit, userConfig->getMotionHomeKit());
 #endif
     JSON_ADD_INT("webRequests", request_count);
     JSON_ADD_INT("webMaxResponseTime", max_response_time);

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -381,6 +381,8 @@ function setElementsFromStatus(status) {
                 document.getElementById("obstFromStatusRow").style.display = (value != 3) ? "table-row" : "none";
                 document.getElementById("dcDebounceDurationRow").style.display = (value == 3) ? "table-row" : "none";
                 document.getElementById("motionMotion").disabled = (value == 2) ? false : true;
+                // Hide Light HomeKit checkbox for dry contact mode (no light control)
+                document.getElementById("lightHomeKitSpan").style.display = (value != 3) ? "inline" : "none";
                 break;
             case "pinBasedObst":
                 document.getElementById(key).innerHTML = (value == true) ? "&nbsp;(Pin-based)" : "&nbsp;(Message)";
@@ -470,6 +472,12 @@ function setElementsFromStatus(status) {
             case "homespanCLI":
                 document.getElementById(key).checked = value;
                 document.getElementById("homespanSetting").style.display = "table-row";
+                break;
+            case "lightHomeKit":
+            case "motionHomeKit":
+                document.getElementById(key).checked = value;
+                // Show the HomeKit Accessories row for ESP32 only
+                document.getElementById("homekitAccessoriesRow").style.display = "table-row";
                 break;
             case "laserHomeKit":
             case "vehicleHomeKit":
@@ -1287,6 +1295,8 @@ async function saveSettings() {
     const list = document.getElementById("timeZoneInput");
     const timeZone = list.options[list.selectedIndex].text + ';' + list.options[list.selectedIndex].value;
     const homespanCLI = (document.getElementById("homespanCLI").checked) ? '1' : '0';
+    const lightHomeKit = (document.getElementById("lightHomeKit").checked) ? '1' : '0';
+    const motionHomeKit = (document.getElementById("motionHomeKit").checked) ? '1' : '0';
 
     // check IP addresses valid
     const regexIPv4 = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/i;
@@ -1332,6 +1342,8 @@ async function saveSettings() {
         "obstFromStatus", obstFromStatus,
         "dcDebounceDuration", dcDebounceDuration,
         "homespanCLI", homespanCLI,
+        "lightHomeKit", lightHomeKit,
+        "motionHomeKit", motionHomeKit,
     );
     if (reboot) {
         countdown(rebootSeconds, "Settings saved, RATGDO device rebooting...&nbsp;");

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -401,6 +401,20 @@
                   </table>
                 </td>
               </tr>
+              <tr id="homekitAccessoriesRow" style="display:none;">
+                <td class="label">HomeKit Accessories:</td>
+                <td>&nbsp;
+                  <span id="lightHomeKitSpan">
+                    <input type="checkbox" id="lightHomeKit" name="lightHomeKit" value="no" checked>
+                    <label for="lightHomeKit">Light</label>
+                  </span>
+                  <span id="motionHomeKitSpan">
+                    <input type="checkbox" id="motionHomeKit" name="motionHomeKit" value="no" checked>
+                    <label for="motionHomeKit">Motion</label>
+                  </span>
+                  <span style="font-size: 0.7em;">&nbsp;(uncheck to hide from Apple Home)</span>
+                </td>
+              </tr>
               <tr id="vehicleSettingsSpacer" style="display:none;">
                 <td colspan="2">&nbsp;</td>
               </tr>


### PR DESCRIPTION
Added toggles to the web UI to give the ability to disable and remove the homekit accessories for the light and motion sensor.

I never ever want to use these in Apple home, so having to see these extra accessories and/or hide them in some unused room (especially the light) is annoying. This fixes that for people like me.

Defaults to having both ON, so it's fully backward compatible and nothing changes upon installing the new firmware until/unless you uncheck these. Removes from apple home immediately without re-pairing.

<img width="795" height="797" alt="Screenshot 2025-12-08 at 2 05 37 PM" src="https://github.com/user-attachments/assets/8dada7b3-1291-4732-9e62-71426d298635" />
