### PR TITLE
Require password change on first boot when default credentials are still in use

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -686,6 +686,24 @@ bool userSettings::set(const std::string &key, const bool value)
     TAKE_MUTEX();
     if (settings.count(key))
     {
+        // Prevent enabling password protection if credentials are still factory-default.
+        if ((key == cfg_passwordRequired) && value)
+        {
+            // Read current stored credentials
+            if (settings.count(cfg_wwwCredentials))
+            {
+                char *stored = std::get<configStr>(settings[cfg_wwwCredentials].value).str;
+                // Factory-default credentials hash (MD5 of default credentials)
+                const char *factory_default_hash = "10d3c00fa1e09696601ef113b99f8a87";
+                if (strncmp(stored, factory_default_hash, 32) == 0)
+                {
+                    ESP_LOGW(TAG, "Refusing to enable password protection: factory default credentials in use");
+                    GIVE_MUTEX();
+                    return false;
+                }
+            }
+        }
+
         if (std::holds_alternative<bool>(settings[key].value))
         {
             settings[key].value = value;

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -61,6 +61,9 @@ static const char *TAG = "ratgdo-http";
 // This is used for CSS, JS and IMAGE file types.  Set to 30 days !!
 #define CACHE_CONTROL (60 * 60 * 24 * 30)
 
+// Per-request setgdo error message (populated by handlers to return specific text)
+static std::string setgdo_error_message = "";
+
 // Forward declare the internal URI handling functions...
 void handle_reset();
 void handle_status();
@@ -821,6 +824,67 @@ void build_status_json(char *json)
     JSON_ADD_BOOL("garageObstructed", garage_door.obstructed);
     JSON_ADD_BOOL("pinBasedObst", garage_door.pinModeObstructionSensor);
     JSON_ADD_BOOL(cfg_passwordRequired, userConfig->getPasswordRequired());
+    // Force password change only on first boot after a new firmware version
+    bool forcePwChange = false;
+    const char *storedCreds = userConfig->getwwwCredentials();
+    const char *factory_default_hash = "10d3c00fa1e09696601ef113b99f8a87";
+
+#ifdef ESP8266
+    // On ESP8266 persist last seen firmware in a small file and a password-set marker
+    String lastSeen = "";
+    const char *lastSeenFile = "/lastSeenFirmware";
+    const char *passwordSetFile = "/passwordSet";
+    bool passwordSet = false;
+    if (LittleFS.exists(passwordSetFile)) {
+        File pf = LittleFS.open(passwordSetFile, "r");
+        if (pf) {
+            String v = pf.readString();
+            pf.close();
+            if (v.toInt() != 0) passwordSet = true;
+        }
+    }
+    if (LittleFS.exists(lastSeenFile)) {
+        File f = LittleFS.open(lastSeenFile, "r");
+        if (f) {
+            lastSeen = f.readString();
+            f.close();
+        }
+    }
+    if (lastSeen != String(AUTO_VERSION)) {
+        if (!passwordSet && storedCreds && (strncmp(storedCreds, factory_default_hash, 32) == 0))
+        {
+            // User hasn't set a non-default password yet; force change
+            forcePwChange = true;
+        }
+        else
+        {
+            // Either password already set or credentials not default; mark this version as seen
+            File f = LittleFS.open(lastSeenFile, "w");
+            if (f) {
+                f.print(AUTO_VERSION);
+                f.close();
+            }
+        }
+    }
+#else
+    // On ESP32 use NVRAM to persist last seen firmware version and a password-set marker
+    std::string lastSeen = nvRam->read("lastSeenFirmware", "");
+    int passwordSet = nvRam->read("passwordSet", 0);
+    if (lastSeen != std::string(AUTO_VERSION)) {
+        if (!passwordSet && storedCreds && (strncmp(storedCreds, factory_default_hash, 32) == 0))
+        {
+            // User hasn't set a non-default password yet; force change
+            forcePwChange = true;
+        }
+        else
+        {
+            // Either password already set or credentials not default; mark this version as seen
+            nvRam->write("lastSeenFirmware", std::string(AUTO_VERSION).c_str(), true);
+        }
+    }
+#endif
+
+    JSON_ADD_BOOL("forcePasswordChange", forcePwChange);
     JSON_ADD_INT(cfg_rebootSeconds, (uint32_t)userConfig->getRebootSeconds());
     JSON_ADD_INT("freeHeap", free_heap);
     JSON_ADD_INT("minHeap", min_heap);
@@ -1071,6 +1135,20 @@ bool helperCredentials(const std::string &key, const char *value, configSetting 
     *strchr(newUsername, '"') = (char)0;
     *strchr(newCredentials, '"') = (char)0;
     *strchr(newPassword, '"') = (char)0;
+#ifdef ESP8266
+    const char *factory_default_hash = "10d3c00fa1e09696601ef113b99f8a87";
+#else
+    const char *factory_default_hash = "10d3c00fa1e09696601ef113b99f8a87";
+#endif
+
+    // Prevent user from setting credentials back to the factory-default hash
+    if (strncmp(newCredentials, factory_default_hash, 32) == 0)
+    {
+        ESP_LOGW(TAG, "Rejected attempt to set credentials to factory default for user: %s", newUsername);
+        setgdo_error_message = "Rejected: cannot set password back to factory default";
+        return false;
+    }
+
     // save values...
     ESP_LOGI(TAG, "Set credentials for user: %s", newUsername);
     userConfig->set(cfg_wwwUsername, newUsername);
@@ -1078,8 +1156,18 @@ bool helperCredentials(const std::string &key, const char *value, configSetting 
 #ifndef ESP8266
     // We only need to save password (distinct from credentials) on ESP32
     write_door_str(nvram_ratgdo_pw, newPassword);
+    // Mark passwordSet and persist lastSeenFirmware so enforcement clears
+    nvRam->write("passwordSet", 1, true);
+    nvRam->write("lastSeenFirmware", std::string(AUTO_VERSION).c_str(), true);
+#else
+    // On ESP8266, create a small file to mark password has been set and persist lastSeenFirmware
+    File pf = LittleFS.open("/passwordSet", "w");
+    if (pf) { pf.print("1"); pf.close(); }
+    File f = LittleFS.open("/lastSeenFirmware", "w");
+    if (f) { f.print(AUTO_VERSION); f.close(); }
 #endif
     ESP8266_SAVE_CONFIG();
+    setgdo_error_message.clear();
     return true;
 }
 
@@ -1215,8 +1303,25 @@ void handle_setgdo()
             }
             else
             {
-                // No function to call, set value directly.
-                userConfig->set(key, value.c_str());
+                // No function to call, set value directly. If set() fails (policy), record error.
+                // Special-case: prevent direct setting of cfg_wwwCredentials back to factory default
+                if (key == cfg_wwwCredentials)
+                {
+                    const char *factory_default_hash = "10d3c00fa1e09696601ef113b99f8a87";
+                    if (strncmp(value.c_str(), factory_default_hash, 32) == 0)
+                    {
+                        ESP_LOGW(TAG, "Rejected direct set of cfg_wwwCredentials to factory default");
+                        setgdo_error_message = "Rejected: cannot set password back to factory default";
+                        error = true;
+                        goto setgdo_loop_end;
+                    }
+                }
+
+                if (!userConfig->set(key, value.c_str()))
+                {
+                    ESP_LOGW(TAG, "Rejected setting Key: %s due to policy or invalid value", key.c_str());
+                    error = true;
+                }
             }
             reboot = reboot || actions.reboot;
             wifiChanged = wifiChanged || actions.wifiChanged;
@@ -1231,12 +1336,21 @@ void handle_setgdo()
         if (error)
             break;
     }
+    setgdo_loop_end:
 
     ESP_LOGV(TAG, "SetGDO Complete");
 
     if (error)
     {
-        // Simple error handling...
+        // If a handler provided a specific error message, prefer that
+        if (!setgdo_error_message.empty())
+        {
+            ESP_LOGE(TAG, "Sending setgdo error: %s, for: %s", setgdo_error_message.c_str(), server.uri().c_str());
+            server.send(400, type_txt, setgdo_error_message.c_str());
+            setgdo_error_message.clear();
+            return;
+        }
+        // Fallback to generic error
         ESP_LOGE(TAG, "Sending %s, for: %s", response400invalid, server.uri().c_str());
         server.send_P(400, type_txt, response400invalid);
         return;

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -425,6 +425,31 @@ function setElementsFromStatus(status) {
             case "passwordRequired":
                 document.getElementById("pwreq").checked = value;
                 break;
+            case "forcePasswordChange":
+                if (value) {
+                    try {
+                        // Show settings for context and present a blocking password modal
+                        showSettings();
+                        // Populate modal username placeholder from server
+                        const mu = document.getElementById('modalUserName');
+                        if (mu) mu.placeholder = document.getElementById('newUserName').placeholder || '';
+                        // Clear modal password fields
+                        const mnp = document.getElementById('modalNewPassword');
+                        const mcp = document.getElementById('modalConfirmPassword');
+                        if (mnp) mnp.value = '';
+                        if (mcp) mcp.value = '';
+                        // Hide modal close button and show pwModal
+                        const pwClose = document.getElementById('pwModalClose');
+                        if (pwClose) pwClose.style.display = 'none';
+                        document.getElementById('pwModal').style.display = 'block';
+                    } catch (e) {
+                        console.warn('Failed to show force-password modal', e);
+                    }
+                } else {
+                    const pw = document.getElementById('pwModal');
+                    if (pw && pw.style.display == 'block') pw.style.display = 'none';
+                }
+                break;
             case "LEDidle":
                 document.getElementById("LEDidle0").checked = (value == 0) ? true : false;
                 document.getElementById("LEDidle1").checked = (value == 1) ? true : false;
@@ -1173,13 +1198,25 @@ async function setGDO(...args) {
                 signal: AbortSignal.timeout(2000),
             });
             if (response.status !== 200) {
-                console.warn("Error setting RATGDO state");
+                // Surface server-provided error message to the user so they know why the change failed
+                let errText = "Error setting RATGDO state";
+                try {
+                    errText = await response.text();
+                } catch (e) {
+                    console.warn("Failed to read error response text", e);
+                }
+                console.warn("Error setting RATGDO state:", errText);
+                alert(`Failed to save settings: ${errText}`);
                 return false;
             }
             else {
                 const result = await response.text();
                 if (result.includes('Reboot')) {
                     console.log('Server settings saved, reboot required');
+                    return true;
+                }
+                // Some successful setGDO calls return HTML "<p>Success.</p>"; treat non-reboot success as success
+                if (result.toLowerCase().includes('success')) {
                     return true;
                 }
                 return false;
@@ -1209,30 +1246,48 @@ async function setGDO(...args) {
 }
 
 async function changePassword() {
-    // newPW defined in index.html
-    if (newPW.value === "") {
+    // Prefer modal inputs if present (modal fields will exist during forced-change flow)
+    const modalNew = document.getElementById('modalNewPassword');
+    const modalConfirm = document.getElementById('modalConfirmPassword');
+    const modalUser = document.getElementById('modalUserName');
+    let newPasswordVal, confirmPasswordVal, www_username;
+    if (modalNew && modalConfirm) {
+        newPasswordVal = modalNew.value;
+        confirmPasswordVal = modalConfirm.value;
+        www_username = (modalUser && modalUser.value) ? modalUser.value.substring(0,30) : (document.getElementById("newUserName").value.substring(0,30));
+    } else {
+        // fallback to settings inputs
+        const newPWelem = document.getElementById("newPassword");
+        const confirmPWelem = document.getElementById("confirmPassword");
+        newPasswordVal = newPWelem ? newPWelem.value : "";
+        confirmPasswordVal = confirmPWelem ? confirmPWelem.value : "";
+        www_username = document.getElementById("newUserName").value.substring(0, 30);
+    }
+    if (newPasswordVal === "") {
         alert("New password cannot be blank");
         return;
     }
-    if (newPW.value !== confirmPW.value) {
+    if (newPasswordVal !== confirmPasswordVal) {
         alert("Passwords do not match");
         return;
     }
-    let www_username = document.getElementById("newUserName").value.substring(0, 30);
     if (www_username.length == 0) www_username = serverStatus.userName ?? "admin";
     const www_realm = "RATGDO Login Required";
     // MD5() function expects a Uint8Array typed ArrayBuffer...
-    const passwordHash = MD5((new TextEncoder).encode(www_username + ":" + www_realm + ":" + newPW.value));
+    const passwordHash = MD5((new TextEncoder).encode(www_username + ":" + www_realm + ":" + newPasswordVal));
     console.log("Set new credentials to: " + passwordHash);
-    await setGDO("credentials", JSON.stringify({
+    const ok = await setGDO("credentials", JSON.stringify({
         username: www_username,
         credentials: passwordHash,
-        password: newPW.value
+        password: newPasswordVal
     }));
     clearTimeout(checkHeartbeat);
-    // On success, go to home page.
-    // User will have to re-authenticate to get back to settings.
-    location.href = "/";
+    if (ok) {
+        // On success, go to home page. User will have to re-authenticate to get back to settings.
+        location.href = "/";
+    } else {
+        // setGDO already alerted the user to the error; keep them on the change-password page.
+    }
     return;
 }
 

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -763,6 +763,38 @@
     </div>
   </div>
 
+  <!-- Password set modal (shown on first boot after update) ------------------------------>
+  <div id="pwModal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <span id="pwModalClose" class="close" style="display:none;">&times;</span>
+      <span id="pwModalTitle">Action Required: Set Username & Password<br></span><br>
+      <div style="float:none; padding:0px;">
+        <table style="width:100%;">
+          <tr>
+            <td class="label">Username:</td>
+            <td><input id="modalUserName" type="text" maxlength="30" minlength="1" placeholder="admin"></td>
+          </tr>
+          <tr>
+            <td class="label">Password:</td>
+            <td><input id="modalNewPassword" type="password" placeholder="new password" autocomplete="new-password"></td>
+          </tr>
+          <tr>
+            <td class="label">Confirm:</td>
+            <td><input id="modalConfirmPassword" type="password" placeholder="confirm new password"></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td><input type="button" value="Save User/Password" onclick="changePassword()"></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td id="modalMatchMsg" style="font-size:0.6em;"><br></td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+
   <!-- Initialization scripts ------------------------------------------------------------------>
   <script>
     // Set global constants


### PR DESCRIPTION
## Summary
This change enforces a username/password update on first boot after a firmware update when the device is still using the factory-default web credentials.

It also blocks attempts to:

enable password protection while factory-default credentials are still configured
reset credentials back to the factory-default hash

## What changed
Added backend enforcement for password-change requirements based on the current firmware version and whether the user has already set non-default credentials.
Persisted password-change state and last-seen firmware version so the prompt is only enforced when needed.
Returned specific server-side error messages for rejected credential and password-protection changes.
Updated the web UI to show a blocking password-change modal during the forced-change flow.
Improved frontend error handling so failed settings updates surface the actual backend rejection reason.
Treated successful non-reboot settings responses consistently in the password-change flow.

## Why
Devices that keep the default credentials after an update remain in an insecure state. This change forces the user to set a real username/password before continuing, while preventing configuration paths that would preserve or restore the default credentials.
