### PR TITLE
fix viewlog.sh: log arg silently dropped without a value, cut buffers output when piped

### DIFF
--- a/viewlog.sh
+++ b/viewlog.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 UUID=$(uuidgen)
-URL=$(curl -s "http://${1}/rest/events/subscribe?id=${UUID}&log")
+URL=$(curl -s "http://${1}/rest/events/subscribe?id=${UUID}&log=1&heartbeat=0")
 curl -s "http://${1}/showlog"
-curl -s -N "http://${1}${URL}?id=${UUID}" | sed -u -n '/event: logger/{n;p;}' | cut -c 7-
+curl -s -N "http://${1}${URL}?id=${UUID}" | sed -n -u '/^event: logger$/{n;s/^data: //p;}'
 exit 0


### PR DESCRIPTION
While working on some other changes I'm hoping to submit, I noticed `viewlog.sh` doesn't actually stream any log lines on my mac.  It will just hang after printing the log history.

Turns out the subscribe call sends `&log` with no value. The ESP32 WebServer parser silently drops any query arg without `=value`, so the subscription never gets flagged as a log viewer and `event: logger` frames are never sent. The device's own `logs.js` already sends `&log=1`, so this just brings the script in line with that. I also added `&heartbeat=0` (also from `logs.js`) so the device doesn't spend a write every second sending status updates to a connection that only wants log messages.

While in there, I also replaced the `sed | cut` tail with a single `sed` command — cut's output doesn't flush until it's piped into something other than a terminal (e.g. `viewlog.sh <host> | grep foo`), which was silently delaying log lines.

Tested locally on macOS... log lines now stream immediately, both directly and through a pipe.