### PR TITLE
Fix false encoder-stopped watchdog trigger from stale timestamp in encoder_loop()

### DIFF
--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -375,7 +375,12 @@ void encoder_loop() {
   }
 
   // Stopped watchdog
-  if (enc_watchdog_armed_ && (now - enc_last_pulse_ms_ >= ENC_STOPPED_MS)) {
+  // Re-read millis() here rather than reusing the stale `now` captured at the
+  // top of this function, since on_encoder_update() above may have taken
+  // long enough (e.g. Debug-level logging) that enc_last_pulse_ms_ ends up
+  // greater than the stale `now`, underflowing this unsigned subtraction.
+  uint32_t watchdog_now = millis();
+  if (enc_watchdog_armed_ && (watchdog_now - enc_last_pulse_ms_ >= ENC_STOPPED_MS)) {
     enc_watchdog_armed_ = false;
     check_encoder_stopped();
   }


### PR DESCRIPTION
Done with Claude assistance, but tested and believe it helped. Glad to answer any follow-up questions.

## Problem

In Dry Contact + rotary encoder mode, `check_encoder_stopped()` fires repeatedly
during normal, continuous door travel instead of only when the door actually
stops. This causes door state to flicker to `Stopped` throughout every
open/close cycle, triggers spurious comms retry errors, and repeatedly writes
encoder calibration to flash — which can drift `enc_min_`/`enc_max_` boundaries
over time and cause a genuinely complete close/open to be misreported.

Reproduced on two independent ratgdo32 boards (different door widths, same
opener model), firmware v3.5.0, Debug log level.

## Root cause

In `encoder_loop()`, `now` is captured once at the top of the function, before
`on_encoder_update()` runs. `enc_last_pulse_ms_` is set at the end of
`on_encoder_update()` via a fresh `millis()` call. If `on_encoder_update()`
takes long enough (it includes logging calls), `enc_last_pulse_ms_` can end up
greater than the stale `now`. Both are `uint32_t`, so
`now - enc_last_pulse_ms_` underflows, immediately exceeding `ENC_STOPPED_MS`
regardless of real elapsed time.

Example, unpatched, Debug level — "stopped" fires 15ms after a step instead of
the intended 3000ms of silence:
D (22:43:23.397) ratgdo-encoder: Encoder step=1 min=0 max=0
I (22:43:23.412) ratgdo-encoder: Encoder stopped: step=1 min=0 max=0 dir=1

## Fix

Re-read `millis()` immediately before the watchdog comparison instead of
reusing the stale value from the top of the function.

## Testing

Built and flashed to one of the two boards used to reproduce this. Same door,
same conditions, Debug log level, full close cycle:
D (00:00:44.194) ratgdo-encoder: Encoder step=46 min=-33 max=48
...continuous steps, no intermediate "stopped" events...
D (00:00:55.794) ratgdo-encoder: Encoder step=15 min=-33 max=48
I (00:00:58.805) ratgdo-encoder: Encoder stopped: step=15 min=-33 max=48 dir=-1

Single "stopped" event, fired 3.01s after the last real step. No flicker, no
spurious retry errors, across repeated cycles. Video confirms the door is
moving continuously throughout affected cycles pre-patch — this is a reporting
defect, not real motion interruption.

Devices that calibrated under the unpatched firmware may have inflated
boundaries from repeated false-trigger writes; a `resetEncoderCal` + one clean
cycle post-patch is recommended.

Can provide full logs (both boards, unpatched/patched), video, and
status.json output if useful.