### PR TITLE
Prevent encoder calibration boundary from drifting inward on in-tolerance snaps

### DIFF
--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -268,14 +268,18 @@ static void check_encoder_stopped() {
     bool beyond_closed = decreasing && (enc_last_ < enc_min_);
 
     if (d_closed <= 1 && d_closed <= d_open && decreasing) {
-      enc_min_ = enc_last_;
-      save = true;
-      ESP_LOGI(TAG, "Encoder: CLOSED snapped to %d", enc_last_);
+      if (enc_last_ <= enc_min_) {
+        enc_min_ = enc_last_;
+        save = true;
+        ESP_LOGI(TAG, "Encoder: CLOSED snapped to %d", enc_last_);
+      }
       notify_state(GarageDoorCurrentState::CURR_CLOSED);
     } else if (d_open <= 1 && d_open < d_closed && !decreasing) {
-      enc_max_ = enc_last_;
-      save = true;
-      ESP_LOGI(TAG, "Encoder: OPEN snapped to %d", enc_last_);
+      if (enc_last_ >= enc_max_) {
+        enc_max_ = enc_last_;
+        save = true;
+        ESP_LOGI(TAG, "Encoder: OPEN snapped to %d", enc_last_);
+      }
       notify_state(GarageDoorCurrentState::CURR_OPEN);
     } else if (beyond_open) {
       enc_max_ = enc_last_;


### PR DESCRIPTION
Done with Claude's assistance - thank you for your time in reviewing. Noticed a drift over days to a point where Apple Homekit believed the door was open after it was closed. Here's what Mr. AI shared:

Summary

In check_encoder_stopped(), a normal within-tolerance stop unconditionally overwrites the calibrated boundary (enc_min_/enc_max_), even when the new stop position is less extreme than the currently recorded boundary. Over many cycles, ordinary ±1-step mechanical variance in stopping position causes the boundary to drift inward. Once drift exceeds the ±1 step snap tolerance, a genuinely complete close or open is reported as Stopped instead of Closed/Open.

This is a separate defect from the false-watchdog-trigger issue fixed in #184 (merged). That fix is confirmed working — this report covers a different code path in the same file.

Root Cause
```
if (d_closed <= 1 && d_closed <= d_open && decreasing) {
  enc_min_ = enc_last_;   // unconditional — overwrites even if enc_last_ is
                          // LESS extreme than the current enc_min_
  save = true;
  ESP_LOGI(TAG, "Encoder: CLOSED snapped to %d", enc_last_);
  notify_state(GarageDoorCurrentState::CURR_CLOSED);
} else if (d_open <= 1 && d_open < d_closed && !decreasing) {
  enc_max_ = enc_last_;   // same issue, opposite direction
  ...
```
Compare to the boundary-extend branches further down, which correctly guard with `enc_last_ < enc_min_` / `enc_last_ > enc_max_` before updating. The snap branches have no equivalent guard: any stop within 1 step of the boundary overwrites it, regardless of direction. A door that stops 1 step short of true closed pulls `enc_min_` inward by 1 step; repeated over many cycles, this walks the boundary steadily away from the door's true physical limit.

Evidence

168+ hour log (device uptime 105 hours shown), firmware v3.5.1, no watchdog flicker present (confirming #184's fix is active and unrelated to this issue). min boundary over successive cycles:
```
I (02:04:50.557) ratgdo-encoder: Encoder: initial min boundary set to 0
I (04:13:21.575) ratgdo-encoder: Encoder: CLOSED snapped to -1
I (11:20:35.255) ratgdo-encoder: Encoder: CLOSED snapped to -2
I (17:11:10.988) ratgdo-encoder: Encoder: CLOSED snapped to -3
I (24:48:46.940) ratgdo-encoder: Encoder: CLOSED snapped to -4
I (25:47:22.840) ratgdo-encoder: Encoder: CLOSED snapped to -5
I (27:40:42.158) ratgdo-encoder: Encoder: CLOSED snapped to -6
I (37:42:26.715) ratgdo-encoder: Encoder: CLOSED snapped to -7
```
Confirmed via /status.json at the time:
```
"garageDoorState": "Stopped",
"encSteps": -4,
```
Apple Home displayed this as appearing open, since HomeKit's Stopped state has no distinct icon in the Home app — a display ambiguity downstream of the real issue, not a separate bug.

Proposed Fix

Apply the same directional guard already used in the boundary-extend branches, so the boundary only tightens toward the door's true physical limit, never loosens:
```
if (d_closed <= 1 && d_closed <= d_open && decreasing) {
-      enc_min_ = enc_last_;
-      save = true;
-      ESP_LOGI(TAG, "Encoder: CLOSED snapped to %d", enc_last_);
+      if (enc_last_ <= enc_min_) {
+        enc_min_ = enc_last_;
+        save = true;
+        ESP_LOGI(TAG, "Encoder: CLOSED snapped to %d", enc_last_);
+      }
       notify_state(GarageDoorCurrentState::CURR_CLOSED);
     } else if (d_open <= 1 && d_open < d_closed && !decreasing) {
-      enc_max_ = enc_last_;
-      save = true;
-      ESP_LOGI(TAG, "Encoder: OPEN snapped to %d", enc_last_);
+      if (enc_last_ >= enc_max_) {
+        enc_max_ = enc_last_;
+        save = true;
+        ESP_LOGI(TAG, "Encoder: OPEN snapped to %d", enc_last_);
+      }
       notify_state(GarageDoorCurrentState::CURR_OPEN);
     }
```

`notify_state(CURR_CLOSED)` / `CURR_OPEN` still fires unconditionally, so a normal within-tolerance stop continues to correctly report Closed/Open. Only the boundary write itself is guarded. Also reduces unnecessary flash writes on ordinary snap cycles that don't represent genuine drift.

Testing

Not yet validated the same way as #184 — that fix was confirmed same-day via before/after logs on a single cycle. This defect only manifests as drift over many cycles (days), so equivalent same-day validation isn't possible. Plan: apply patch, confirm normal build/boot/operation with no regression over a handful of cycles, then monitor min/max in logs over an extended period to confirm no further inward drift.

Thank you as with before - really appreciate this solution and helping provide tuning feedback. 