### PR TITLE
Fix LAN WiFi auth, JSON overflow, and door-state safety bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 All notable changes to `homekit-ratgdo32` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### What's Changed
+
+* Bugfix: Require web authentication for WiFi provisioning endpoints (`/setssid`, `/wifinets`, `/rescan`, `/wifiap`) when not in Soft AP mode
+* Bugfix: Bound status JSON writer so long SSIDs/names cannot overflow the status JSON heap buffer
+* Bugfix: Encoder direction-correction close now bypasses time-to-close delay
+* Bugfix: Null-check log timestamp parsing and stop mutating credential/OTA JSON in place
+* Bugfix: Count SSE subscriptions only after the client slot is validated
+* Bugfix: Compare previous SSID (not BSSID) when deciding whether to reset WiFi settings
+* Bugfix: HTML-escape SSIDs in the Soft AP table and use `textContent` for device/network names in the web UI
+* Bugfix: Dry-contact both-limits-active reports stopped instead of closed
+* Bugfix: HomeSpan garage-door `update()` only opens/closes or locks when that characteristic actually changed
+
 ## v3.5.1 (2026-07-22)
 
 ### What's Changed
@@ -454,4 +468,3 @@ Note: The built-in TTC feature operates slightly differently than ratgdo's timer
 ### Known Issues
 
 * THIS IS PRE-RELEASE FIRMWARE for testing purposes. Future updates MAY include breaking changes requiring a flash erase and re-upload.
-

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -102,7 +102,7 @@ static char syslogIPBuf[IP4ADDR_STRLEN_MAX] PROGMEM = "0.0.0.0";
 static char timezoneBuf[64] PROGMEM = "";
 static char ntpServerBuf[64] PROGMEM = "pool.ntp.org";
 static char usernameBuf[32] PROGMEM = "admin";
-static char credentialsBuf[36] PROGMEM = "10d3c00fa1e09696601ef113b99f8a87"; // MD5 hash of "admin:ratgdo:password"
+static char credentialsBuf[36] PROGMEM = "10d3c00fa1e09696601ef113b99f8a87"; // MD5 hash of "admin:RATGDO Login Required:password"
 
 //  key, reboot, wifiChanged, value, fn_to_call
 static configSetting settings_defaults[] PROGMEM = {

--- a/src/drycontact.cpp
+++ b/src/drycontact.cpp
@@ -109,12 +109,16 @@ void drycontact_loop()
 
     if (doorControlType == 3)
     {
-        if (dryContactDoorOpen)
+        if (dryContactDoorOpen && dryContactDoorClose)
+        {
+            ESP_LOGW(TAG, "Both open and close limit switches active; reporting stopped");
+            doorState = GarageDoorCurrentState::CURR_STOPPED;
+        }
+        else if (dryContactDoorOpen)
         {
             doorState = GarageDoorCurrentState::CURR_OPEN;
         }
-
-        if (dryContactDoorClose)
+        else if (dryContactDoorClose)
         {
             doorState = GarageDoorCurrentState::CURR_CLOSED;
         }

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -311,7 +311,7 @@ static void check_encoder_stopped() {
     if (intended > 0)
       open_door();
     else
-      close_door(false);
+      close_door(true);
   }
 }
 

--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -1045,12 +1045,17 @@ DEV_GarageDoor::DEV_GarageDoor() : Service::GarageDoorOpener()
 
 boolean DEV_GarageDoor::update()
 {
-    ESP_LOGD(TAG, "Garage Door Characteristics Update, door target: %s", DOOR_STATE(target->getNewVal()));
-    GarageDoorCurrentState state = (target->getNewVal() == target->OPEN) ? open_door() : close_door();
-    obstruction->setVal(false);
-    current->setVal(state);
+    // HomeSpan calls update() when any characteristic in this service changes.
+    // Only act on the characteristic(s) that were actually written.
+    if (target->updated())
+    {
+        ESP_LOGD(TAG, "Garage Door Characteristics Update, door target: %s", DOOR_STATE(target->getNewVal()));
+        GarageDoorCurrentState state = (target->getNewVal() == target->OPEN) ? open_door() : close_door();
+        obstruction->setVal(false);
+        current->setVal(state);
+    }
 
-    if (userConfig->getGDOSecurityType() != 3)
+    if (userConfig->getGDOSecurityType() != 3 && lockTarget && lockTarget->updated())
     {
         // Dry contact cannot control lock
         set_lock(lockTarget->getNewVal() == lockTarget->LOCK);

--- a/src/json.h
+++ b/src/json.h
@@ -13,90 +13,114 @@
  *
  */
 
-inline char *start_json(char *s)
+#pragma once
+
+#include <cstring>
+#include <cstdint>
+#include <string>
+
+// Keep room for JSON_END ("\n}\0") so a truncated object is still valid JSON.
+constexpr size_t JSON_END_RESERVE = 3;
+
+inline bool json_has_room(const char *s, const char *end, size_t n)
 {
-    return stpcpy(s, "{\n");
+    return s && end && (end > s) && ((size_t)(end - s) > n + JSON_END_RESERVE);
+}
+
+inline char *json_puts(char *s, const char *end, const char *v)
+{
+    if (!s || !v)
+        return s;
+    while (*v && json_has_room(s, end, 1))
+    {
+        *s++ = *v++;
+    }
+    if (s && end && s < end)
+        *s = 0;
+    return s;
+}
+
+inline char *start_json(char *s, const char *end)
+{
+    return json_puts(s, end, "{\n");
 }
 
 inline char *remove_comma_nl(char *s)
 {
     // remove the comma newline added by last add_xxxx() function
-    if (*(s - 1) == '\n')
+    if (s && *(s - 1) == '\n')
         s--;
-    if (*(s - 1) == ',')
+    if (s && *(s - 1) == ',')
         s--;
     return s;
 }
 
-inline char *end_json(char *s, bool remove_nl = true)
+inline char *end_json(char *s, const char *end, bool remove_nl = true)
 {
     if (remove_nl)
         s = remove_comma_nl(s);
-    return stpcpy(s, "\n}");
+    return json_puts(s, end, "\n}");
 }
 
-inline char *add_int(char *s, const char *k, int64_t v)
+inline char *add_int(char *s, const char *end, const char *k, int64_t v)
 {
+    std::string num = std::to_string(v);
+    size_t need = 1 + strlen(k) + 3 + num.size() + 2; // "k": num,\n
+    if (!json_has_room(s, end, need))
+        return s;
     *s++ = '"';
-    s = stpcpy(s, k);
+    s = json_puts(s, end, k);
     *s++ = '"';
     *s++ = ':';
     *s++ = ' ';
-    s = stpcpy(s, std::to_string(v).c_str());
+    s = json_puts(s, end, num.c_str());
     *s++ = ',';
     *s++ = '\n';
-    *s = 0; // null terminate
+    *s = 0;
     return s;
 }
 
-inline char *add_int(char *s, const char *k, uint64_t v)
+inline char *add_int(char *s, const char *end, const char *k, uint64_t v)
 {
+    std::string num = std::to_string(v);
+    size_t need = 1 + strlen(k) + 3 + num.size() + 2;
+    if (!json_has_room(s, end, need))
+        return s;
     *s++ = '"';
-    s = stpcpy(s, k);
+    s = json_puts(s, end, k);
     *s++ = '"';
     *s++ = ':';
     *s++ = ' ';
-    s = stpcpy(s, std::to_string(v).c_str());
+    s = json_puts(s, end, num.c_str());
     *s++ = ',';
     *s++ = '\n';
-    *s = 0; // null terminate
+    *s = 0;
     return s;
 }
 
-inline char *add_int(char *s, const char *k, int32_t v)
+inline char *add_int(char *s, const char *end, const char *k, int32_t v)
 {
-    *s++ = '"';
-    s = stpcpy(s, k);
-    *s++ = '"';
-    *s++ = ':';
-    *s++ = ' ';
-    s = stpcpy(s, std::to_string(v).c_str());
-    *s++ = ',';
-    *s++ = '\n';
-    *s = 0; // null terminate
-    return s;
+    return add_int(s, end, k, (int64_t)v);
 }
 
-inline char *add_int(char *s, const char *k, uint32_t v)
+inline char *add_int(char *s, const char *end, const char *k, uint32_t v)
 {
-    *s++ = '"';
-    s = stpcpy(s, k);
-    *s++ = '"';
-    *s++ = ':';
-    *s++ = ' ';
-    s = stpcpy(s, std::to_string(v).c_str());
-    *s++ = ',';
-    *s++ = '\n';
-    *s = 0; // null terminate
-    return s;
+    return add_int(s, end, k, (int64_t)v);
 }
 
-inline char *add_str(char *s, const char *k, const char *v, bool raw = false, bool comma_nl = true)
+inline char *add_str(char *s, const char *end, const char *k, const char *v, bool raw = false, bool comma_nl = true)
 {
+    size_t vlen = v ? strlen(v) : 0;
+    size_t klen = k ? strlen(k) : 0;
+    // Worst case: every value char is escaped.
+    size_t need = (k ? klen + 4 : 0) + (raw ? vlen : vlen * 2 + 2) + (comma_nl ? 2 : 0);
+    if (!json_has_room(s, end, need))
+        return s;
+
     if (k) // if key provided add it
     {
         *s++ = '"';
-        s = stpcpy(s, k);
+        s = json_puts(s, end, k);
         *s++ = '"';
         *s++ = ':';
         *s++ = ' ';
@@ -110,7 +134,7 @@ inline char *add_str(char *s, const char *k, const char *v, bool raw = false, bo
         if (raw)
         {
             // Do not wrap the value in quotes
-            s = stpcpy(s, v);
+            s = json_puts(s, end, v);
         }
         else
         {
@@ -120,8 +144,12 @@ inline char *add_str(char *s, const char *k, const char *v, bool raw = false, bo
             {
                 if (*v == '"' || *v == '\\')
                 {
+                    if (!json_has_room(s, end, 2))
+                        break;
                     *s++ = '\\';
                 }
+                if (!json_has_room(s, end, 1))
+                    break;
                 *s++ = *v++;
             }
             *s++ = '"';
@@ -132,35 +160,50 @@ inline char *add_str(char *s, const char *k, const char *v, bool raw = false, bo
         *s++ = ',';
         *s++ = '\n';
     }
-    *s = 0; // null terminate
+    *s = 0;
     return s;
 }
 
-inline char *add_bool(char *s, const char *k, bool v)
+inline char *add_bool(char *s, const char *end, const char *k, bool v)
 {
+    const char *b = v ? "true" : "false";
+    size_t need = 1 + strlen(k) + 3 + strlen(b) + 2;
+    if (!json_has_room(s, end, need))
+        return s;
     *s++ = '"';
-    s = stpcpy(s, k);
+    s = json_puts(s, end, k);
     *s++ = '"';
     *s++ = ':';
     *s++ = ' ';
-    s = stpcpy(s, v ? "true" : "false");
+    s = json_puts(s, end, b);
     *s++ = ',';
     *s++ = '\n';
-    *s = 0; // null terminate
+    *s = 0;
     return s;
 }
 
-#define JSON_START(buf) char *_json_p = start_json(buf)
-#define JSON_END() end_json(_json_p)
-#define JSON_ADD_INT(k, v) _json_p = add_int(_json_p, k, v)
-#define JSON_ADD_STR(k, v) _json_p = add_str(_json_p, k, v)
-#define JSON_ADD_BOOL(k, v) _json_p = add_bool(_json_p, k, v)
-#define JSON_ADD_RAW(k, v) _json_p = add_str(_json_p, k, v, true)               // value added without surrounding quotes
-#define JSON_INSERT_COMMA_NL() _json_p = add_str(_json_p, nullptr, ",\n", true) // insert a comma newline
-#define JSON_START_OBJ(k) _json_p = add_str(_json_p, k, "{\n", true, false)     // added without surrounding quotes and no comma newline
-#define JSON_END_OBJ() _json_p = add_str(_json_p, nullptr, "\n}", true)         // close curly without quotes and with comma newline
-#define JSON_START_ARRAY(k) _json_p = add_str(_json_p, k, "[\n", true, false)   // added without surrounding quotes and no comma newline
-#define JSON_END_ARRAY() _json_p = add_str(_json_p, nullptr, "\n]", true)       // close array without quotes and with comma newline
+#ifndef JSON_BUFFER_SIZE
+#ifdef STATUS_JSON_BUFFER_SIZE
+#define JSON_BUFFER_SIZE STATUS_JSON_BUFFER_SIZE
+#else
+#define JSON_BUFFER_SIZE 2048
+#endif
+#endif
+
+#define JSON_START(buf)                              \
+    char *_json_buf = (buf);                         \
+    const char *_json_end = _json_buf + JSON_BUFFER_SIZE; \
+    char *_json_p = start_json(_json_buf, _json_end)
+#define JSON_END() end_json(_json_p, _json_end)
+#define JSON_ADD_INT(k, v) _json_p = add_int(_json_p, _json_end, k, v)
+#define JSON_ADD_STR(k, v) _json_p = add_str(_json_p, _json_end, k, v)
+#define JSON_ADD_BOOL(k, v) _json_p = add_bool(_json_p, _json_end, k, v)
+#define JSON_ADD_RAW(k, v) _json_p = add_str(_json_p, _json_end, k, v, true)               // value added without surrounding quotes
+#define JSON_INSERT_COMMA_NL() _json_p = add_str(_json_p, _json_end, nullptr, ",\n", true) // insert a comma newline
+#define JSON_START_OBJ(k) _json_p = add_str(_json_p, _json_end, k, "{\n", true, false)     // added without surrounding quotes and no comma newline
+#define JSON_END_OBJ() _json_p = add_str(_json_p, _json_end, nullptr, "\n}", true)         // close curly without quotes and with comma newline
+#define JSON_START_ARRAY(k) _json_p = add_str(_json_p, _json_end, k, "[\n", true, false)   // added without surrounding quotes and no comma newline
+#define JSON_END_ARRAY() _json_p = add_str(_json_p, _json_end, nullptr, "\n]", true)       // close array without quotes and with comma newline
 
 #define JSON_ADD_INT_C(k, v, ov) \
     {                            \

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -215,7 +215,8 @@ void LOG::logToBuffer(const char *fmt, va_list args)
     vsnprintf(lineBuffer, LINE_BUFFER_SIZE, fmt, args);
     // If timestamp is wrapped in () and not [] then message is from one of the ESP_LOGx() functions.
     // Convert the milliseconds into HH:MM:SS.mmm so it is easier to read.
-    if (strchr(lineBuffer, '(') - lineBuffer == 2)
+    char *open_paren = strchr(lineBuffer, '(');
+    if (open_paren && open_paren - lineBuffer == 2)
     {
         char *numptr = &lineBuffer[3];
         char *endptr;

--- a/src/softAP.cpp
+++ b/src/softAP.cpp
@@ -14,6 +14,7 @@
  */
 
 // Arduino system includes
+#include <cstring>
 #include <DNSServer.h>
 
 // RATGDO project includes
@@ -324,6 +325,56 @@ void handle_wifiap()
     return load_page("/wifiap.html");
 }
 
+// Escape untrusted SSID text before embedding it in HTML.
+static void htmlEscape(const char *in, char *out, size_t outLen)
+{
+    if (!out || outLen == 0)
+        return;
+    size_t o = 0;
+    if (!in)
+    {
+        out[0] = 0;
+        return;
+    }
+    for (; *in && o + 1 < outLen; ++in)
+    {
+        const char *rep = NULL;
+        switch (*in)
+        {
+        case '&':
+            rep = "&amp;";
+            break;
+        case '<':
+            rep = "&lt;";
+            break;
+        case '>':
+            rep = "&gt;";
+            break;
+        case '"':
+            rep = "&quot;";
+            break;
+        case '\'':
+            rep = "&#39;";
+            break;
+        default:
+            break;
+        }
+        if (rep)
+        {
+            size_t n = strlen(rep);
+            if (o + n >= outLen)
+                break;
+            memcpy(out + o, rep, n);
+            o += n;
+        }
+        else
+        {
+            out[o++] = *in;
+        }
+    }
+    out[o] = 0;
+}
+
 void handle_wifinets()
 {
     bool connected = WiFi.isConnected();
@@ -355,14 +406,18 @@ void handle_wifinets()
         {
             matchSSID = false;
         }
+        char escapedSSID[192];
+        htmlEscape(net.ssid.c_str(), escapedSSID, sizeof(escapedSSID));
         snprintf(txtBuffer, TXT_BUFFER_SIZE, softAPtableRow, (hide) ? "class='adv'" : "", i, i, (matchSSID) ? "checked='checked'" : "", i,
-                 net.ssid.c_str(), net.rssi, net.channel,
+                 escapedSSID, net.rssi, net.channel,
                  net.bssid[0], net.bssid[1], net.bssid[2], net.bssid[3], net.bssid[4], net.bssid[5]);
         server.sendContent(txtBuffer, strlen(txtBuffer));
         i++;
     }
     // user entered value
-    snprintf(txtBuffer, TXT_BUFFER_SIZE, softAPtableLastRow, i, i, (!match) ? previousSSID.c_str() : "");
+    char escapedSSID[192];
+    htmlEscape((!match) ? previousSSID.c_str() : "", escapedSSID, sizeof(escapedSSID));
+    snprintf(txtBuffer, TXT_BUFFER_SIZE, softAPtableLastRow, i, i, escapedSSID);
     server.sendContent(txtBuffer, strlen(txtBuffer));
     server.sendContent("\n", 1);
     server.client().stop();
@@ -446,7 +501,7 @@ bool set_new_ssid(const char *ssid, const char *password, const uint8_t *bssid)
         homeSpan.setWifiCredentials(ssid, password);
 #endif
         // We should reset WiFi if changing networks or were not currently connected.
-        if (!connected || previousBSSID != ssid)
+        if (!connected || previousSSID != ssid)
         {
             userConfig->set(cfg_staticIP, false);
             userConfig->set(cfg_wifiPower, WIFI_POWER_MAX);

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -610,6 +610,26 @@ String *ratgdoAuthenticate(HTTPAuthMethod mode, String enteredUsernameOrReq, Str
         return server.requestAuthentication(DIGEST_AUTH, www_realm);
 #endif
 
+// Returns false if a 401 challenge was sent. Unlike AUTHENTICATE(), this does not return
+// from the caller, so dispatchers can still unregister the request.
+static bool requestAuthenticated()
+{
+#ifdef ESP8266
+    if (userConfig->getPasswordRequired() && !server.authenticateDigest(userConfig->getwwwUsername(), userConfig->getwwwCredentials()))
+    {
+        server.requestAuthentication(DIGEST_AUTH, www_realm);
+        return false;
+    }
+#else
+    if (userConfig->getPasswordRequired() && !server.authenticate(ratgdoAuthenticate))
+    {
+        server.requestAuthentication(DIGEST_AUTH, www_realm);
+        return false;
+    }
+#endif
+    return true;
+}
+
 void handle_auth()
 {
     AUTHENTICATE();
@@ -743,6 +763,18 @@ void handle_everything()
         ESP_LOGD(TAG, "Client %s requesting: %s (method: %s)", server.client().remoteIP().toString().c_str(), uri, http_methods[method]);
         if (method == builtInUri.at(uri).first)
         {
+            // WiFi provisioning is unauthenticated in Soft AP mode, but must
+            // require credentials once the device is on the LAN.
+            if (!softAPmode &&
+                (!strcmp(uri, "/setssid") || !strcmp(uri, "/wifinets") ||
+                 !strcmp(uri, "/rescan") || !strcmp(uri, "/wifiap")))
+            {
+                if (!requestAuthenticated())
+                {
+                    unregisterRequest();
+                    return;
+                }
+            }
             builtInUri.at(uri).second();
         }
         else
@@ -771,6 +803,14 @@ void handle_everything()
     else if (method == HTTP_GET || method == HTTP_HEAD)
     {
         // HTTP_GET that does not match a built-in handler
+        if (!softAPmode && page.equals("/wifiap.html"))
+        {
+            if (!requestAuthenticated())
+            {
+                unregisterRequest();
+                return;
+            }
+        }
         if (page.equals("/"))
         {
             load_page("/index.html");
@@ -1065,29 +1105,71 @@ bool helperGarageLockState(const std::string &key, const char *value, configSett
     return true;
 }
 
-bool helperCredentials(const std::string &key, const char *value, configSetting *action)
+// Extract a JSON string value for "key" without mutating the source.
+static bool jsonExtractString(const char *json, const char *key, char *out, size_t outLen)
 {
-    const char *newUsername = strstr(value, "username");
-    const char *newCredentials = strstr(value, "credentials");
-    const char *newPassword = strstr(value, "password");
-    if (!(newUsername && newCredentials && newPassword))
+    if (!json || !key || !out || outLen == 0)
         return false;
 
-    // JSON string passed in.
-    // Very basic parsing, not using library functions to save memory
-    // find the colon after the key string
-    newUsername = strchr(newUsername, ':') + 1;
-    newCredentials = strchr(newCredentials, ':') + 1;
-    newPassword = strchr(newPassword, ':') + 1;
-    // for strings find the double quote
-    newUsername = strchr(newUsername, '"') + 1;
-    newCredentials = strchr(newCredentials, '"') + 1;
-    newPassword = strchr(newPassword, '"') + 1;
-    // null terminate the strings (at closing quote).
-    *strchr(newUsername, '"') = (char)0;
-    *strchr(newCredentials, '"') = (char)0;
-    *strchr(newPassword, '"') = (char)0;
-    // save values...
+    char pattern[40];
+    snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+    const char *p = strstr(json, pattern);
+    if (!p)
+        return false;
+    p = strchr(p + strlen(pattern), ':');
+    if (!p)
+        return false;
+    p++;
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+        p++;
+    if (*p != '"')
+        return false;
+    p++;
+    size_t i = 0;
+    while (*p && *p != '"' && i + 1 < outLen)
+    {
+        if (*p == '\\' && p[1])
+            p++;
+        out[i++] = *p++;
+    }
+    if (*p != '"')
+        return false;
+    out[i] = 0;
+    return true;
+}
+
+static bool jsonExtractInt(const char *json, const char *key, int *out)
+{
+    if (!json || !key || !out)
+        return false;
+
+    char pattern[40];
+    snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+    const char *p = strstr(json, pattern);
+    if (!p)
+        return false;
+    p = strchr(p + strlen(pattern), ':');
+    if (!p)
+        return false;
+    p++;
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+        p++;
+    if (*p == '\0' || *p == ',')
+        return false;
+    *out = atoi(p);
+    return true;
+}
+
+bool helperCredentials(const std::string &key, const char *value, configSetting *action)
+{
+    char newUsername[32];
+    char newCredentials[36];
+    char newPassword[64];
+    if (!jsonExtractString(value, "username", newUsername, sizeof(newUsername)) ||
+        !jsonExtractString(value, "credentials", newCredentials, sizeof(newCredentials)) ||
+        !jsonExtractString(value, "password", newPassword, sizeof(newPassword)))
+        return false;
+
     ESP_LOGI(TAG, "Set credentials for user: %s", newUsername);
     userConfig->set(cfg_wwwUsername, newUsername);
     userConfig->set(cfg_wwwCredentials, newCredentials);
@@ -1103,29 +1185,17 @@ bool helperUpdateUnderway(const std::string &key, const char *value, configSetti
 {
     firmwareSize = 0;
     firmwareUpdateSub = NULL;
-    const char *md5 = strstr(value, "md5");
-    const char *size = strstr(value, "size");
-    const char *uuid = strstr(value, "uuid");
+    char md5[36];
+    char uuid[64];
+    int size = 0;
 
-    if (!(md5 && size && uuid))
+    if (!jsonExtractString(value, "md5", md5, sizeof(md5)) ||
+        !jsonExtractInt(value, "size", &size) ||
+        !jsonExtractString(value, "uuid", uuid, sizeof(uuid)))
         return false;
 
-    // JSON string of passed in.
-    // Very basic parsing, not using library functions to save memory
-    // find the colon after the key string
-    md5 = strchr(md5, ':') + 1;
-    size = strchr(size, ':') + 1;
-    uuid = strchr(uuid, ':') + 1;
-    // for strings find the double quote
-    md5 = strchr(md5, '"') + 1;
-    uuid = strchr(uuid, '"') + 1;
-    // null terminate the strings (at closing quote).
-    *strchr(md5, '"') = (char)0;
-    *strchr(uuid, '"') = (char)0;
-    // ESP_LOGI(TAG,"MD5: %s, UUID: %s, Size: %d", md5, uuid, atoi(size));
-    // save values...
     strlcpy(firmwareMD5, md5, sizeof(firmwareMD5));
-    firmwareSize = atoi(size);
+    firmwareSize = (size_t)size;
     for (uint32_t channel = 0; channel < SSE_MAX_CHANNELS; channel++)
     {
         if (subscription[channel].SSEconnected && subscription[channel].clientUUID == uuid && subscription[channel].client.connected())
@@ -1503,11 +1573,6 @@ void handle_subscribe()
         for (channel = 0; channel < SSE_MAX_CHANNELS; channel++)
             if (subscription[channel].clientIP == IPAddress(INADDR_NONE))
                 break;
-
-        if (channel < SSE_MAX_CHANNELS)
-        {
-            subscriptionCount++;
-        }
     }
 
     // Check if we found a free slot
@@ -1545,6 +1610,10 @@ void handle_subscribe()
             heartbeatInterval = (uint32_t)hbi;
         }
     }
+
+    // Count only after the slot is validated and about to be assigned
+    if (!foundExisting)
+        subscriptionCount++;
 
     // Safe assignment with validation
     subscription[channel].clientIP = clientIP;

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -24,6 +24,11 @@ var setGDOcmds = {              // setGDO commands that are not sent from server
 var gitUser = "ratgdo";         // default git user.
 var gitRepo = "homekit-ratgdo"; // default git repository.
 
+function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = (value == null) ? "" : String(value);
+}
+
 // See... https://github.com/nayarsystems/posix_tz_db
 // This is CSV form of the data, available at this web page.
 const timeZonesURL = "https://raw.githubusercontent.com/nayarsystems/posix_tz_db/refs/heads/master/zones.csv";
@@ -426,11 +431,11 @@ function setElementsFromStatus(status) {
                 document.getElementById("sec1emulation").style.display = (value == true) ? "" : "none";
                 break;
             case "deviceName":
-                document.getElementById(key).innerHTML = value;
+                setText(key, value);
                 document.title = value;
                 document.getElementById("newDeviceName").placeholder = value;
                 let mdnsName = makeRfc952(value) + ".local";
-                document.getElementById("mdnsName").innerHTML = mdnsName;
+                setText("mdnsName", mdnsName);
                 break;
             case "userName":
                 document.getElementById("newUserName").placeholder = value;
@@ -582,8 +587,8 @@ function setElementsFromStatus(status) {
                 document.getElementById("dcDebounceValue").innerHTML = value;
                 break;
             case "firmwareVersion":
-                document.getElementById(key).innerHTML = value;
-                document.getElementById("firmwareVersion2").innerHTML = value;
+                setText(key, value);
+                setText("firmwareVersion2", value);
                 break;
             case "wifiPhyMode":
                 document.getElementById("trWifiPhyMode").style.display = "table-row";
@@ -605,25 +610,25 @@ function setElementsFromStatus(status) {
                 break;
             case "accessoryID":
                 document.getElementById("trAccessoryID").style.display = "table-row";
-                document.getElementById(key).innerHTML = value;
+                setText(key, value);
                 break;
             case "clients":
                 document.getElementById(key).innerHTML = (value > 0) ? `Yes (${value})` : 'No';
                 break;
             case "localIP":
-                document.getElementById(key).innerHTML = value;
+                setText(key, value);
                 document.getElementById("IPaddress").placeholder = value;
                 break;
             case "ipv6Addresses":
                 document.getElementById("trEnableIPv6").style.display = "table-row";
-                document.getElementById(key).innerHTML = value.split(',').join('\n');
+                setText(key, value.split(',').join('\n'));
                 break;
             case "subnetMask":
-                document.getElementById(key).innerHTML = value;
+                setText(key, value);
                 document.getElementById("IPnetmask").placeholder = value;
                 break;
             case "gatewayIP":
-                document.getElementById(key).innerHTML = value;
+                setText(key, value);
                 document.getElementById("IPgateway").placeholder = value;
                 break;
             case "nameserverIP":
@@ -634,7 +639,7 @@ function setElementsFromStatus(status) {
                 document.getElementById("staticIPtable").style.display = (value) ? "table" : "none";
                 break;
             case "syslogIP":
-                document.getElementById(key).innerHTML = value;
+                setText(key, value);
                 document.getElementById("syslogIP").placeholder = value;
                 break;
             case "syslogPort":
@@ -761,7 +766,7 @@ function setElementsFromStatus(status) {
                 try {
                     if (setGDOcmds[key] == undefined) {
                         // Only try and set if the key is not a setGDO command
-                        document.getElementById(key).innerHTML = value;
+                        setText(key, value);
                     }
                 } catch (error) {
                     console.warn(`Server sent unrecognized status: ${key} : ${value}`);

--- a/src/www/logs.js
+++ b/src/www/logs.js
@@ -149,7 +149,7 @@ async function loadLogPages() {
             })
             .then((text) => {
                 msgJson = JSON.parse(text);
-                document.getElementById("deviceName").innerHTML = msgJson.deviceName;
+                document.getElementById("deviceName").textContent = msgJson.deviceName;
                 document.title = msgJson.deviceName;
                 document.getElementById("statusjson").innerText = text;
             })


### PR DESCRIPTION
These fixes were originally drafted against `homekit-ratgdo` (ESP8266). That was the wrong repository. This PR applies the confirmed bugs, plus an ESP32-only HomeSpan issue, to `homekit-ratgdo32`.

## Fixes

**Auth / web**
- Require digest auth for WiFi provisioning endpoints (`/setssid`, `/wifinets`, `/rescan`, `/wifiap`, GET `/wifiap.html`) when the device is on the LAN and `passwordRequired` is enabled. Soft AP mode stays unauthenticated as intended.
- Bound the status JSON writer so long SSIDs/device names cannot overflow the heap buffer.
- Parse credential and OTA JSON without mutating the source string (avoids NULL deref on malformed input).
- Increment SSE `subscriptionCount` only after the client slot is validated.

**Door / encoder / dry contact**
- Encoder direction-correction close uses `close_door(true)` so time-to-close delay is not applied to a safety retry.
- Dry-contact both-limits-active reports STOPPED instead of CLOSED.

**ESP32 HomeSpan**
- `DEV_GarageDoor::update()` only opens/closes or changes lock when that characteristic was actually written. Previously a lock request also opened/closed the door (and vice versa).

**Other**
- Compare previous SSID (not BSSID) when deciding whether to reset WiFi settings after a network change.
- HTML-escape SSIDs in the Soft AP table; use `textContent` for device/network names in the web UI.
- Null-check `strchr` in log timestamp parsing.
- Comment on the default digest-auth MD5 hash now matches the actual realm string.

Unauthenticated `/reboot` and `/status.json` are left as documented behavior.

`src/comms.cpp` is unchanged versus `main` in this PR.