### PR TITLE
Encoder is the sole physical state source in Dry Contact mode

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -970,7 +970,8 @@ inline void handle_protocol_door_state(GarageDoorCurrentState state)
 #ifdef RATGDO_ENCODER
     if (encoder_enabled)
     {
-        protocol_received_state(state);
+        if (doorControlType != DOOR_CONTROL_DRY_CONTACT)
+            protocol_received_state(state);
         return;
     }
 #endif

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -166,6 +166,12 @@ static void encoder_received(GarageDoorCurrentState door_state)
 {
   garage_door.encoder_door_state = door_state;
 
+  if (doorControlType == 3)
+  {
+      update_door_state(door_state);
+      return;
+  }
+
   GarageDoorCurrentState proto_state = garage_door.protocol_door_state;
 
   if (proto_state == (GarageDoorCurrentState)0xFF)


### PR DESCRIPTION
I believe this addresses the phantom door states in Dry Contact mode described in [my comment on #188](https://github.com/ratgdo/homekit-ratgdo32/issues/188#issuecomment-5378169881).