### PR TITLE
Add opt-in door-open laser trigger with HomeKit state sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ For ratgdo32-disco boards, if you have the parking assist [laser accessory](http
 When enabled, you can configure how long the laser remains on during parking assist by selecting a value from zero to 300 seconds (5 minutes). Selecting
 zero disables parking assist laser. Parking assist is triggered if an arriving vehicle is detected with 5 minutes of the door opening or closing.
 
+Check **Trigger on Door Open** to also fire the laser immediately when the door starts opening, instead of waiting for vehicle-arrival detection. This is useful if vehicle presence sensing is slow or unreliable on your install. It's off by default and independent of the vehicle-arrival trigger above - either or both can be enabled at the same time.
+
 ### Door Protocol
 
 Set the protocol for your model of garage door opener. This defaults to Security+ 2.0 and you should only change this if necessary. Note that the changing the door protocol also resets the door opener rolling codes and whether there is a motion sensor (this will be automatically detected after reset).

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -158,6 +158,7 @@ static configSetting settings_defaults[] PROGMEM = {
     {cfg_vehicleDepartingHomeKit, false, false, true, helperVehicleDepartingHomeKit}, // granular control for departing motion sensor
     {cfg_laserEnabled, false, false, false, helperLaser},
     {cfg_laserHomeKit, false, false, true, helperLaser}, // call fn to enable/disable HomeKit accessories
+    {cfg_laserOnDoorOpen, false, false, false, NULL},
     {cfg_assistDuration, false, false, 60, NULL},
     {cfg_TTCsound, false, false, true, NULL},
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -108,6 +108,7 @@ constexpr char cfg_vehicleArrivingHomeKit[] PROGMEM = "vehicleArrivingHomeKit";
 constexpr char cfg_vehicleDepartingHomeKit[] PROGMEM = "vehicleDepartingHomeKit";
 constexpr char cfg_laserEnabled[] PROGMEM = "laserEnabled";
 constexpr char cfg_laserHomeKit[] PROGMEM = "laserHomeKit";
+constexpr char cfg_laserOnDoorOpen[] PROGMEM = "laserOnDoorOpen";
 constexpr char cfg_assistDuration[] PROGMEM = "assistDuration";
 constexpr char cfg_TTCsound[] PROGMEM = "TTCsound";
 #endif
@@ -225,6 +226,7 @@ public:
     uint32_t getVehicleThreshold() { return std::get<int>(get(cfg_vehicleThreshold)); };
     bool getLaserEnabled() { return std::get<bool>(get(cfg_laserEnabled)); };
     bool getLaserHomeKit() { return std::get<bool>(get(cfg_laserHomeKit)); };
+    bool getLaserOnDoorOpen() { return std::get<bool>(get(cfg_laserOnDoorOpen)); };
     bool getVehicleHomeKit() { return std::get<bool>(get(cfg_vehicleHomeKit)); };
     bool getVehicleOccupancyHomeKit() { return std::get<bool>(get(cfg_vehicleOccupancyHomeKit)); };
     bool getVehicleArrivingHomeKit() { return std::get<bool>(get(cfg_vehicleArrivingHomeKit)); };

--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -702,6 +702,9 @@ bool enable_service_homekit_laser(bool enable)
             new SpanAccessory(HOMEKIT_AID_LASER);
             new DEV_Info("Laser");
             assistLaser = new DEV_Light(Light_t::ASSIST_LASER);
+            // Keep HomeKit in sync with the physical laser regardless of what
+            // triggers a state change (web UI, vehicle presence, flash() auto-off).
+            laser.onChange(notify_homekit_laser);
             homeSpan.updateDatabase();
             return true;
         }

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -38,18 +38,24 @@ void LED::on()
 {
     digitalWrite(pin, onState);
     currentState = onState;
+    if (stateChangeCallback)
+        stateChangeCallback(state());
 }
 
 void LED::off()
 {
     digitalWrite(pin, offState);
     currentState = offState;
+    if (stateChangeCallback)
+        stateChangeCallback(state());
 }
 
 void LED::idle()
 {
     digitalWrite(pin, idleState);
     currentState = idleState;
+    if (stateChangeCallback)
+        stateChangeCallback(state());
 }
 
 void LED::setIdleState(uint8_t state)
@@ -77,6 +83,8 @@ void LED::flash(uint64_t ms)
     {
         digitalWrite(pin, activeState);
         currentState = activeState;
+        if (stateChangeCallback)
+            stateChangeCallback(state());
         LEDtimer.once_ms(ms, [this]()
                          { this->idle(); });
     }

--- a/src/led.h
+++ b/src/led.h
@@ -29,6 +29,7 @@ private:
     uint8_t idleState = 0; // opposite of active
     uint8_t currentState = 0;
     Ticker LEDtimer;
+    void (*stateChangeCallback)(bool) = nullptr;
 
 public:
     explicit LED(uint8_t gpio_num, uint8_t state = 1);
@@ -39,6 +40,9 @@ public:
     void flash(uint64_t ms = FLASH_MS);
     void setIdleState(uint8_t state);
     uint8_t getIdleState() { return idleState; };
+    // Register a callback fired with the new on/off state whenever it changes,
+    // regardless of what triggered the change (manual call or flash() auto-off).
+    void onChange(void (*cb)(bool)) { stateChangeCallback = cb; };
 };
 
 extern LED led;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -261,6 +261,7 @@ void load_all_config_settings()
     ESP_LOGI(TAG, "     vehicleDeparting:  %s", userConfig->getVehicleDepartingHomeKit() ? "true" : "false");
     ESP_LOGI(TAG, "   laserEnabled:        %s", userConfig->getLaserEnabled() ? "true" : "false");
     ESP_LOGI(TAG, "   laserHomeKit:        %s", userConfig->getLaserHomeKit() ? "true" : "false");
+    ESP_LOGI(TAG, "   laserOnDoorOpen:     %s", userConfig->getLaserOnDoorOpen() ? "true" : "false");
     ESP_LOGI(TAG, "   assistDuration:      %d", userConfig->getAssistDuration());
 #endif
 #ifndef ESP8266

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -331,7 +331,8 @@ void doorOpening()
     // Fire the parking assist laser immediately on door open rather than waiting for
     // vehicle presence to be confirmed... by the time presence debounces, the door may
     // already be closed and the vehicle parked, which is too late to assist parking.
-    if (userConfig->getAssistDuration() > 0)
+    // Opt-in: off by default so existing distance-triggered behavior is unaffected.
+    if (userConfig->getLaserOnDoorOpen() && userConfig->getAssistDuration() > 0)
         laser.flash(userConfig->getAssistDuration() * 1000);
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -327,6 +327,12 @@ void doorOpening()
         return;
 
     presence_timer = _millis();
+
+    // Fire the parking assist laser immediately on door open rather than waiting for
+    // vehicle presence to be confirmed... by the time presence debounces, the door may
+    // already be closed and the vehicle parked, which is too late to assist parking.
+    if (userConfig->getAssistDuration() > 0)
+        laser.flash(userConfig->getAssistDuration() * 1000);
 }
 
 // if notified of door closing, check for arrived/departed vehicle within time window (looking back)

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -980,6 +980,7 @@ void build_status_json(char *json)
     JSON_ADD_INT(cfg_vehicleThreshold, userConfig->getVehicleThreshold());
     JSON_ADD_BOOL(cfg_laserEnabled, userConfig->getLaserEnabled());
     JSON_ADD_BOOL(cfg_laserHomeKit, userConfig->getLaserHomeKit());
+    JSON_ADD_BOOL(cfg_laserOnDoorOpen, userConfig->getLaserOnDoorOpen());
     JSON_ADD_INT(cfg_assistDuration, userConfig->getAssistDuration());
     JSON_ADD_BOOL(cfg_TTCsound, userConfig->getTTCsound());
 #endif

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -1266,7 +1266,6 @@ bool helperAssistLaser(const std::string &key, const char *value, configSetting 
         laser.on();
     else
         laser.off();
-    notify_homekit_laser(atoi(value) == 1);
     return true;
 }
 #endif

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -180,6 +180,7 @@ function toggleEncoderOptions() {
 // enable laser
 function enableLaser(value) {
     document.getElementById('laserHomeKit').disabled = !value;
+    document.getElementById('laserOnDoorOpen').disabled = !value;
     document.getElementById("laserButton").style.display = (value) ? "inline-block" : "none";
     document.getElementById("assistDuration").disabled = !value;
     document.getElementById("parkAssist").style.opacity = value ? "1" : "0.5";
@@ -494,6 +495,7 @@ function setElementsFromStatus(status) {
                 document.getElementById("vehicleSettingsSpacer").style.display = (value) ? "table-row" : "none";
                 setVehicleConfigVisibility(value);
                 document.getElementById("laserSetting").style.display = (value) ? "table-row" : "none";
+                document.getElementById("laserOnDoorOpenRow").style.display = (value) ? "table-row" : "none";
                 break;
             case "vehicleThreshold":
                 document.getElementById(key).value = value;
@@ -508,6 +510,7 @@ function setElementsFromStatus(status) {
                 document.getElementById(key).checked = value;
                 document.getElementById("laserButton").style.display = (value) ? "inline-block" : "none";
                 document.getElementById("laserHomeKit").disabled = !value;
+                document.getElementById("laserOnDoorOpen").disabled = !value;
                 document.getElementById("parkAssist").style.display = (value) ? "table-row" : "none";
                 break;
             case "homespanCLI":
@@ -531,6 +534,7 @@ function setElementsFromStatus(status) {
                 setVehicleSensorOptionState(value);
                 break;
             case "laserHomeKit":
+            case "laserOnDoorOpen":
             case "useToggle":
             case "useSWserial":
             case "obstFromStatus":
@@ -1435,6 +1439,7 @@ async function saveSettings() {
     const vehicleDepartingHomeKit = (document.getElementById("vehicleDepartingHomeKit").checked) ? '1' : '0';
     const laserEnabled = (document.getElementById("laserEnabled").checked) ? '1' : '0';
     const laserHomeKit = (document.getElementById("laserHomeKit").checked) ? '1' : '0';
+    const laserOnDoorOpen = (document.getElementById("laserOnDoorOpen").checked) ? '1' : '0';
     const dcOpenClose = (document.getElementById("dcOpenClose").checked) ? '1' : '0';
     const dcBypassTTC = (document.getElementById("dcBypassTTC").checked) ? '1' : '0';
     const useToggle = (document.getElementById("useToggle").checked) ? '1' : '0';
@@ -1511,6 +1516,7 @@ async function saveSettings() {
         "vehicleDepartingHomeKit", vehicleDepartingHomeKit,
         "laserEnabled", laserEnabled,
         "laserHomeKit", laserHomeKit,
+        "laserOnDoorOpen", laserOnDoorOpen,
         "dcOpenClose", dcOpenClose,
         "dcBypassTTC", dcBypassTTC,
         "useToggle", useToggle,

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -482,6 +482,13 @@
                   <label for="laserHomeKit">HomeKit Light Switch</label>
                 </td>
               </tr>
+              <tr id="laserOnDoorOpenRow" style="display:none;">
+                <td></td>
+                <td>
+                  <input type="checkbox" id="laserOnDoorOpen" name="laserOnDoorOpen" value="no" disabled>
+                  <label for="laserOnDoorOpen">Trigger on Door Open</label>
+                </td>
+              </tr>
               <tr>
                 <td></td>
                 <td>

--- a/src/www/status.json
+++ b/src/www/status.json
@@ -53,6 +53,7 @@
   "vehicleDist": 300,
   "laserEnabled": true,
   "laserHomeKit": true,
+  "laserOnDoorOpen": false,
   "vehicleHomeKit": true,
   "vehicleOccupancyHomeKit": true,
   "vehicleArrivingHomeKit": true,


### PR DESCRIPTION
## What this does

Two related changes, stacked as separate commits so they're individually reviewable:

1. **Fire the parking-assist laser immediately on door-open**, instead of waiting for
   vehicle-presence detection. On my install, vehicle-presence debounce was taking 6+
   minutes to trigger, which defeats the point of a *parking assist* laser. This is
   gated by a new opt-in checkbox ("Trigger on Door Open") — off by default, so it
   changes nothing for anyone not using it, and can be combined with the existing
   vehicle-arrival trigger rather than replacing it.

2. **Sync HomeKit's laser toggle with firmware-initiated state changes.** Today, the
   HomeKit toggle only reflects the laser's state when it's changed manually (via
   HomeKit or the web page) — it doesn't update when the firmware turns the laser on
   or off itself (vehicle-arrival trigger, the new door-open trigger, or the auto-off
   timer). This fixes that gap generally, not just for the new trigger.

## Testing

- Both changes have been running on my ratgdo32-disco hardware for several weeks
  (since mid-July) with no issues.
- Verified: door-open trigger fires reliably and respects the configured assist
  duration; HomeKit toggle now correctly reflects laser state for all three
  firmware-initiated triggers, not just manual toggling.
- README updated to document the new checkbox.

## Notes

- Rebased against current `main` immediately before opening this PR.
- Happy to split into two PRs if you'd prefer reviewing them separately — they're
  already separate commits for exactly that reason.